### PR TITLE
🔧 Add checkout step to GitHub Actions workflow for secret management

### DIFF
--- a/.github/workflows/set-common-github-secrets.yml
+++ b/.github/workflows/set-common-github-secrets.yml
@@ -7,6 +7,9 @@ jobs:
   set-secrets:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Generate GitHub App token
         id: generate-token
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION

## 📒 変更点の概要

- GitHub Actions ワークフロー `.github/workflows/set-common-github-secrets.yml` に新たに `Checkout` ステップを追加しました。

## ⚒ 技術的な詳細

- `Checkout` ステップは、GitHub Actions の公式アクション `actions/checkout@v4` を使用しています。このステップは、リポジトリのコードをワークフローの実行環境にチェックアウトするために必要です。
- これにより、後続のステップでリポジトリの内容にアクセスできるようになります。

## ⚠ 注意点

- `Checkout` ステップを追加することで、ワークフローの実行時間が若干増加する可能性がありますが、リポジトリの内容を必要とするステップがある場合には必須です。

> [!NOTE]
>
> - この変更は、GitHub Actions ワークフローの実行において、リポジトリの内容を利用するための準備を整えるものです。