### PR TITLE
🔧 GitHub Actionsの権限変更とTerraformモジュールのトピック更新

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: read
+      contents: write
       deployments: write # Required for bobheadxi/deployments
       id-token: write # Required for aws-actions/configure-aws-credentials
       pull-requests: write # Required for bobheadxi/deployments

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -23,9 +23,9 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      deployments: write
-      id-token: write
-      pull-requests: write
+      deployments: write # Required for bobheadxi/deployments
+      id-token: write # Required for aws-actions/configure-aws-credentials
+      pull-requests: write # Required for bobheadxi/deployments
     steps:
       - uses: actions/checkout@v4
 

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -1,8 +1,6 @@
 module "tqer39" {
-  source = "../../modules/repository"
-
-  github_token = var.github_token
-
+  source         = "../../modules/repository"
+  github_token   = var.github_token
   repository     = "tqer39"
   default_branch = "main"
   topics         = ["profile"]
@@ -18,15 +16,12 @@ module "tqer39" {
 }
 
 module "renovate_config" {
-  source = "../../modules/repository"
-
-  github_token = var.github_token
-
+  source         = "../../modules/repository"
+  github_token   = var.github_token
   repository     = "renovate-config"
   default_branch = "main"
   topics         = ["renovate"]
   description    = "Renovate Configuration."
-
   branches_to_protect = {
     "main" = {
       required_status_checks        = true
@@ -41,7 +36,7 @@ module "terraform_aws" {
   github_token   = var.github_token
   repository     = "terraform-aws"
   default_branch = "main"
-  topics         = ["aws"]
+  topics         = ["terraform", "aws"]
   description    = "Configure AWS resources with Terraform."
   branches_to_protect = {
     "main" = {
@@ -57,7 +52,7 @@ module "terraform_github" {
   github_token   = var.github_token
   repository     = "terraform-github"
   default_branch = "main"
-  topics         = ["github"]
+  topics         = ["terraform", "github"]
   description    = "Configure GitHub resources with Terraform."
   branches_to_protect = {
     "main" = {
@@ -73,7 +68,7 @@ module "terraform_vercel" {
   github_token   = var.github_token
   repository     = "terraform-vercel"
   default_branch = "main"
-  topics         = ["vercel"]
+  topics         = ["terraform", "vercel"]
   description    = "Configure Vercel resources with Terraform."
   branches_to_protect = {
     "main" = {


### PR DESCRIPTION

## 📒 変更点の概要

- GitHub Actionsのワークフローにおける権限設定を変更し、`contents`の権限を`read`から`write`に変更しました。
- Terraformモジュールのトピックを更新し、関連性を向上させました。

## ⚒ 技術的な詳細

- `.github/workflows/terraform-github.yml`ファイルにおいて、`contents`の権限を`write`に変更しました。これにより、ワークフローがリポジトリの内容を変更できるようになります。
  - `deployments`、`id-token`、`pull-requests`の権限には、必要な理由をコメントとして追加しました。
- `terraform/src/repository/main.tf`ファイルでは、各モジュールの`topics`を更新しました。
  - `terraform-aws`モジュールのトピックに`terraform`を追加。
  - `terraform-github`モジュールのトピックに`terraform`を追加。
  - `terraform-vercel`モジュールのトピックに`terraform`を追加。

## ⚠ 注意点

> [!WARNING]
>
> - 💣 この変更には、GitHub Actionsの権限が`write`に変更されるため、リポジトリの内容に対する変更が可能になります。適切なアクセス制御を行ってください。