### PR TITLE
🔧 Terraform設定の整理とGitHubリポジトリのホームページURL追加

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write
+      contents: write # Required for update the repository
       deployments: write # Required for bobheadxi/deployments
       id-token: write # Required for aws-actions/configure-aws-credentials
       pull-requests: write # Required for bobheadxi/deployments

--- a/terraform/modules/repository/github_repository.tf
+++ b/terraform/modules/repository/github_repository.tf
@@ -1,6 +1,7 @@
 resource "github_repository" "this" {
   name                   = var.repository
   description            = var.description
+  homepage_url           = var.homepage_url
   visibility             = var.visibility
   topics                 = var.topics
   has_issues             = var.has_issues

--- a/terraform/modules/repository/variables.tf
+++ b/terraform/modules/repository/variables.tf
@@ -124,3 +124,9 @@ variable "verified_allowed" {
   description = "(Optional) Whether actions in GitHub Marketplace from verified creators are allowed. Set to true to allow all GitHub Marketplace actions by verified creators."
   default     = true
 }
+
+variable "homepage_url" {
+  type        = string
+  description = "(Optional) URL of the repository homepage."
+  default     = null
+}

--- a/terraform/src/repository/.terraform.lock.hcl
+++ b/terraform/src/repository/.terraform.lock.hcl
@@ -37,30 +37,6 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/github" {
-  version = "5.21.1"
-  hashes = [
-    "h1:50uWaep+GEPgkzwVGcECJFQCoUxD4JZK+QjugUeOYr4=",
-    "h1:G+XXPOTEc4H9Q9WzJjiowUENPCmpJ37SyJKl7InEZ9Q=",
-    "h1:Hs1bWY8YnM0Ve7gZc+QY1HcpOGVs3yZwjRMx9q/HFd4=",
-    "h1:e0BrGh3T4gimkqgROHyWdOzFRAKRT3U0SUt7vwN9Iac=",
-    "zh:4a55c2257b108faaded434bbc4491c5efc39dc41e6514d7050e15e39ee1f2ac9",
-    "zh:765b7b99d9c7522aede4e200166331f3c8093505ba3330309f2fe93d2a4a7f71",
-    "zh:80fb20f2e83f9eb786e85971a91e3a5ca141a9d68deac6b786c1860ce9b482a8",
-    "zh:868abaa9ca998e24d84af85a1e3722901d7c274dbf88a53847964450a6931b73",
-    "zh:8e9254a1508d0afc27510ec6a43d215a600dc7a870cf541803f5298dc32a6c07",
-    "zh:9249f58e07c8a2b725272c444b2ff70f4e6e0ba59a95433840adde1295246ce0",
-    "zh:9613d3bc76f64a54d85ba2feb0fc1feac0205437864ce1ff47d38772a9bb9285",
-    "zh:a153f986cd88ec2ab43c6dae1efb82f66d8277b597619e7ab6b6d1494ea676de",
-    "zh:a5b37268078be1739915cca7afff017de8543191527cc995ccf33e324b92fad9",
-    "zh:aca22cd1d5f2c5e6692c0c3392312b160ec70a7087f7075fccb7c3e0996448a2",
-    "zh:b15a4ce4760f18d6aa03c17fa1049c3ba797ae437452f6277251ac47ba791b60",
-    "zh:b8b3b0b885e89b449779bf73bfd6dbc53103b9d8eaac13bad2b95b8a035f5100",
-    "zh:dc11d7ee4bff6990c81216e96de2b9de43ab8b6a8d82532888f587fb6080720f",
-    "zh:fb8afed924acdd8d9bb773d518a30857b59ca260a94ac8107c03b23afb1ef3e7",
-  ]
-}
-
 provider "registry.terraform.io/integrations/github" {
   version     = "6.6.0"
   constraints = "6.6.0"

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -139,8 +139,3 @@ import {
   id = openai_generate_pr_description
   to = module.openai_generate_pr_description.github_branch_protection.this["main"]
 }
-
-import {
-  id = openai_generate_pr_description
-  to = module.openai_generate_pr_description.github_repository.this
-}

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -126,16 +126,19 @@ module "openai_generate_pr_description" {
 }
 
 import {
-  id = openai_generate_pr_description
+  id = "tqer39/openai-generate-pr-description"
   to = module.openai_generate_pr_description.github_repository.this
 }
 
-import {
-  id = openai_generate_pr_description
-  to = module.openai_generate_pr_description.github_branch_default.this
-}
 
-import {
-  id = openai_generate_pr_description
-  to = module.openai_generate_pr_description.github_branch_protection.this["main"]
-}
+# import {
+#   id = openai_generate_pr_description
+#   to = module.openai_generate_pr_description.github_branch_default.this
+# }
+
+# import {
+#   id = openai_generate_pr_description
+#   to = module.openai_generate_pr_description.github_branch_protection.this["main"]
+# }
+
+# aws-vault exec portfolio -- terraform -chdir=./terraform/src/repository import "module.github_branch_default.this[\"main\"]" openai_generate_pr_description/main

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -85,6 +85,7 @@ module "blog" {
   default_branch = "main"
   topics         = ["blog"]
   description    = "Configure blog resources with Terraform."
+  homepage_url   = "https://blog-tqer39s-projects.vercel.app"
   branches_to_protect = {
     "main" = {
       required_status_checks        = true

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -126,15 +126,15 @@ module "openai_generate_pr_description" {
   }
 }
 
-import {
-  id = "tqer39/openai-generate-pr-description"
-  to = module.openai_generate_pr_description.github_repository.this
-}
+# import {
+#   id = "tqer39/openai-generate-pr-description"
+#   to = module.openai_generate_pr_description.github_repository.this
+# }
 
-import {
-  id = "tqer39/blog"
-  to = module.blog.github_repository.this
-}
+# import {
+#   id = "tqer39/blog"
+#   to = module.blog.github_repository.this
+# }
 
 
 # import {

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -130,6 +130,11 @@ import {
   to = module.openai_generate_pr_description.github_repository.this
 }
 
+import {
+  id = "tqer39/blog"
+  to = module.blog.github_repository.this
+}
+
 
 # import {
 #   id = openai_generate_pr_description

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -125,26 +125,3 @@ module "openai_generate_pr_description" {
     }
   }
 }
-
-# import {
-#   id = "tqer39/openai-generate-pr-description"
-#   to = module.openai_generate_pr_description.github_repository.this
-# }
-
-# import {
-#   id = "tqer39/blog"
-#   to = module.blog.github_repository.this
-# }
-
-
-# import {
-#   id = openai_generate_pr_description
-#   to = module.openai_generate_pr_description.github_branch_default.this
-# }
-
-# import {
-#   id = openai_generate_pr_description
-#   to = module.openai_generate_pr_description.github_branch_protection.this["main"]
-# }
-
-# aws-vault exec portfolio -- terraform -chdir=./terraform/src/repository import "module.github_branch_default.this[\"main\"]" openai_generate_pr_description/main

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -124,3 +124,23 @@ module "openai_generate_pr_description" {
     }
   }
 }
+
+import {
+  id = openai_generate_pr_description
+  to = module.openai_generate_pr_description.github_repository.this
+}
+
+import {
+  id = openai_generate_pr_description
+  to = module.openai_generate_pr_description.github_branch_default.this
+}
+
+import {
+  id = openai_generate_pr_description
+  to = module.openai_generate_pr_description.github_branch_protection.this["main"]
+}
+
+import {
+  id = openai_generate_pr_description
+  to = module.openai_generate_pr_description.github_repository.this
+}


### PR DESCRIPTION

## 📒 変更点の概要

- `.terraform.lock.hcl`から不要なGitHubプロバイダーの設定を削除しました。
- `main.tf`内の不要なインポートをコメントアウトし、整理しました。
- GitHubリポジトリにホームページURLの変数を追加し、ブログモジュールに設定を適用しました。
- GitHub Actionsの権限を更新し、リポジトリの更新に必要なコメントを追加しました。

## ⚒ 技術的な詳細

- `.terraform.lock.hcl`から`registry.terraform.io/hashicorp/github`プロバイダーの設定を削除し、`registry.terraform.io/integrations/github`プロバイダーを使用するように変更しました。
- `main.tf`では、不要なインポートをコメントアウトし、必要なインポートのみを残しました。
- `variables.tf`に`homepage_url`変数を追加し、`github_repository.tf`でこの変数を使用してリポジトリのホームページURLを設定しました。
- GitHub Actionsの`terraform-github.yml`で、`contents`権限にコメントを追加し、リポジトリの更新に必要であることを明示しました。

## ⚠ 注意点

- 💡 `homepage_url`の設定はオプションであり、必要に応じて設定してください。
- 💡 GitHub Actionsの権限設定を変更したため、ワークフローの動作に影響がないか確認が必要です。