### PR TITLE
🚀 Terraformモジュールの整理とファイル分割

### DIFF
--- a/terraform/src/repository/blog.tf
+++ b/terraform/src/repository/blog.tf
@@ -1,17 +1,15 @@
-
-
-module "time_capsule" {
+module "blog" {
   source         = "../../modules/repository"
   github_token   = var.github_token
-  repository     = "time-capsule"
+  repository     = "blog"
   default_branch = "main"
-  topics         = ["time-capsule", "nextjs"]
-  description    = "Create a time capsule repository."
+  topics         = ["blog"]
+  description    = "Configure blog resources with Terraform."
+  homepage_url   = "https://blog-tqer39s-projects.vercel.app"
   branches_to_protect = {
     "main" = {
       required_status_checks        = true
       required_pull_request_reviews = true
-      status_check_contexts         = ["pre-commit"]
     }
   }
 }

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -1,19 +1,3 @@
-module "terraform_aws" {
-  source         = "../../modules/repository"
-  github_token   = var.github_token
-  repository     = "terraform-aws"
-  default_branch = "main"
-  topics         = ["terraform", "aws"]
-  description    = "Configure AWS resources with Terraform."
-  branches_to_protect = {
-    "main" = {
-      required_status_checks        = true
-      required_pull_request_reviews = true
-      status_check_contexts         = ["pre-commit", "terraform-aws-management", "terraform-aws-portfolio", "terraform-aws-sandbox"]
-    }
-  }
-}
-
 module "terraform_github" {
   source         = "../../modules/repository"
   github_token   = var.github_token

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -1,20 +1,3 @@
-module "tqer39" {
-  source         = "../../modules/repository"
-  github_token   = var.github_token
-  repository     = "tqer39"
-  default_branch = "main"
-  topics         = ["profile"]
-  description    = "personal information repository"
-
-  branches_to_protect = {
-    "main" = {
-      # GitHub Action のワークフローで main に push するために必要
-      allows_force_pushes           = true
-      required_pull_request_reviews = true
-    }
-  }
-}
-
 module "renovate_config" {
   source         = "../../modules/repository"
   github_token   = var.github_token

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -29,19 +29,3 @@ module "time_capsule" {
     }
   }
 }
-
-module "openai_generate_pr_description" {
-  source         = "../../modules/repository"
-  github_token   = var.github_token
-  repository     = "openai-generate-pr-description"
-  default_branch = "main"
-  topics         = ["openai"]
-  description    = "Generate Pull Request description with OpenAI."
-  branches_to_protect = {
-    "main" = {
-      required_status_checks        = true
-      required_pull_request_reviews = true
-      status_check_contexts         = ["pre-commit"]
-    }
-  }
-}

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -1,18 +1,3 @@
-module "terraform_vercel" {
-  source         = "../../modules/repository"
-  github_token   = var.github_token
-  repository     = "terraform-vercel"
-  default_branch = "main"
-  topics         = ["terraform", "vercel"]
-  description    = "Configure Vercel resources with Terraform."
-  branches_to_protect = {
-    "main" = {
-      required_status_checks        = true
-      required_pull_request_reviews = true
-    }
-  }
-}
-
 module "blog" {
   source         = "../../modules/repository"
   github_token   = var.github_token

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -1,19 +1,3 @@
-module "terraform_github" {
-  source         = "../../modules/repository"
-  github_token   = var.github_token
-  repository     = "terraform-github"
-  default_branch = "main"
-  topics         = ["terraform", "github"]
-  description    = "Configure GitHub resources with Terraform."
-  branches_to_protect = {
-    "main" = {
-      required_status_checks        = true
-      required_pull_request_reviews = true
-      status_check_contexts         = ["pre-commit", "terraform-github"]
-    }
-  }
-}
-
 module "terraform_vercel" {
   source         = "../../modules/repository"
   github_token   = var.github_token

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -1,19 +1,3 @@
-module "renovate_config" {
-  source         = "../../modules/repository"
-  github_token   = var.github_token
-  repository     = "renovate-config"
-  default_branch = "main"
-  topics         = ["renovate"]
-  description    = "Renovate Configuration."
-  branches_to_protect = {
-    "main" = {
-      required_status_checks        = true
-      required_pull_request_reviews = true
-      status_check_contexts         = ["pre-commit"]
-    }
-  }
-}
-
 module "terraform_aws" {
   source         = "../../modules/repository"
   github_token   = var.github_token

--- a/terraform/src/repository/main.tf
+++ b/terraform/src/repository/main.tf
@@ -1,5 +1,3 @@
-
-
 module "time_capsule" {
   source         = "../../modules/repository"
   github_token   = var.github_token

--- a/terraform/src/repository/openai-generate-pr-description.tf
+++ b/terraform/src/repository/openai-generate-pr-description.tf
@@ -1,0 +1,15 @@
+module "openai_generate_pr_description" {
+  source         = "../../modules/repository"
+  github_token   = var.github_token
+  repository     = "openai-generate-pr-description"
+  default_branch = "main"
+  topics         = ["openai"]
+  description    = "Generate Pull Request description with OpenAI."
+  branches_to_protect = {
+    "main" = {
+      required_status_checks        = true
+      required_pull_request_reviews = true
+      status_check_contexts         = ["pre-commit"]
+    }
+  }
+}

--- a/terraform/src/repository/renovate-config.tf
+++ b/terraform/src/repository/renovate-config.tf
@@ -1,0 +1,15 @@
+module "renovate_config" {
+  source         = "../../modules/repository"
+  github_token   = var.github_token
+  repository     = "renovate-config"
+  default_branch = "main"
+  topics         = ["renovate"]
+  description    = "Renovate Configuration."
+  branches_to_protect = {
+    "main" = {
+      required_status_checks        = true
+      required_pull_request_reviews = true
+      status_check_contexts         = ["pre-commit"]
+    }
+  }
+}

--- a/terraform/src/repository/terraform-aws.tf
+++ b/terraform/src/repository/terraform-aws.tf
@@ -1,0 +1,15 @@
+module "terraform_aws" {
+  source         = "../../modules/repository"
+  github_token   = var.github_token
+  repository     = "terraform-aws"
+  default_branch = "main"
+  topics         = ["terraform", "aws"]
+  description    = "Configure AWS resources with Terraform."
+  branches_to_protect = {
+    "main" = {
+      required_status_checks        = true
+      required_pull_request_reviews = true
+      status_check_contexts         = ["pre-commit", "terraform-aws-management", "terraform-aws-portfolio", "terraform-aws-sandbox"]
+    }
+  }
+}

--- a/terraform/src/repository/terraform-github.tf
+++ b/terraform/src/repository/terraform-github.tf
@@ -1,0 +1,15 @@
+module "terraform_github" {
+  source         = "../../modules/repository"
+  github_token   = var.github_token
+  repository     = "terraform-github"
+  default_branch = "main"
+  topics         = ["terraform", "github"]
+  description    = "Configure GitHub resources with Terraform."
+  branches_to_protect = {
+    "main" = {
+      required_status_checks        = true
+      required_pull_request_reviews = true
+      status_check_contexts         = ["pre-commit", "terraform-github"]
+    }
+  }
+}

--- a/terraform/src/repository/terraform-vercel.tf
+++ b/terraform/src/repository/terraform-vercel.tf
@@ -1,0 +1,14 @@
+module "terraform_vercel" {
+  source         = "../../modules/repository"
+  github_token   = var.github_token
+  repository     = "terraform-vercel"
+  default_branch = "main"
+  topics         = ["terraform", "vercel"]
+  description    = "Configure Vercel resources with Terraform."
+  branches_to_protect = {
+    "main" = {
+      required_status_checks        = true
+      required_pull_request_reviews = true
+    }
+  }
+}

--- a/terraform/src/repository/tqer39.tf
+++ b/terraform/src/repository/tqer39.tf
@@ -1,0 +1,16 @@
+module "tqer39" {
+  source         = "../../modules/repository"
+  github_token   = var.github_token
+  repository     = "tqer39"
+  default_branch = "main"
+  topics         = ["profile"]
+  description    = "personal information repository"
+
+  branches_to_protect = {
+    "main" = {
+      # GitHub Action のワークフローで main に push するために必要
+      allows_force_pushes           = true
+      required_pull_request_reviews = true
+    }
+  }
+}


### PR DESCRIPTION

## 📒 変更点の概要

- `main.tf` ファイルから各モジュールを個別のファイルに移動しました。これにより、モジュールごとの管理が容易になり、コードの可読性が向上しました。
- 不要な空行を削除し、コードの整形を行いました。

## ⚒ 技術的な詳細

- 以下のモジュールが `main.tf` からそれぞれの専用ファイルに移動されました:
  - `terraform_aws` -> `terraform-aws.tf`
  - `terraform_github` -> `terraform-github.tf`
  - `terraform_vercel` -> `terraform-vercel.tf`
  - `openai_generate_pr_description` -> `openai-generate-pr-description.tf`
  - `blog` -> `blog.tf`
  - `renovate_config` -> `renovate-config.tf`
  - `tqer39` -> `tqer39.tf`

- 各モジュールの設定内容は変更されておらず、移動のみが行われています。

## ⚠ 注意点

- 💡 各モジュールのファイル分割により、今後のメンテナンスが容易になりますが、モジュール間の依存関係がある場合は注意が必要です。
- 💡 ファイルの移動に伴い、Terraformの実行環境でのファイルパスの変更が必要になる場合があります。適切にパスを設定してください。