### PR TITLE
🔄 GitHubトークンの環境変数名を変更し、Terraform Applyアクションを更新

### DIFF
--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -4,7 +4,7 @@ name: Terraform Apply
 description: Terraform Apply
 
 inputs:
-  GITHUB_APPS_TOKEN:
+  GITHUB_TOKEN:
     description: GitHub App トークン
     required: true
   working-directory:
@@ -18,5 +18,5 @@ runs:
       run: terraform apply -auto-approve
       working-directory: ${{ inputs.working-directory }}
       env:
-        TF_VAR_github_token: ${{ inputs.GITHUB_APPS_TOKEN }}
+        TF_VAR_github_token: ${{ inputs.GITHUB_TOKEN }}
       shell: bash

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -57,11 +57,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           env: ${{ env.AWS_ENV_NAME }}
 
+      # NOTE: GitHub App では個人アカウントのリポジトリを作成することが仕様上不可能なので PAT を使用する。
       - uses: ./.github/actions/terraform-apply
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         with:
           working-directory: ./terraform/src/repository
-          GITHUB_APPS_TOKEN: ${{ steps.app_token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
 
       - name: Finish Deployment
         if: always() && github.ref == 'refs/heads/main'


### PR DESCRIPTION

## 📒 変更概要

- 🔄 `GITHUB_APPS_TOKEN`を`GITHUB_TOKEN`に変更しました。
- 🔄 `.github/actions/terraform-apply/action.yml`と`.github/workflows/terraform-github.yml`のファイルを更新しました。

## ⚒ 技術的詳細

- 🔧 `action.yml`ファイル内で、入力変数`GITHUB_APPS_TOKEN`を`GITHUB_TOKEN`に変更しました。
- 🔧 `terraform apply`コマンド実行時に使用する環境変数`TF_VAR_github_token`も同様に更新しました。
- 🔧 `terraform-github.yml`内で、GitHub Appの仕様により個人アカウントのリポジトリ作成が不可能なため、Personal Access Token (PAT)を使用するようにコメントを追加しました。

## ⚠ 注意点

- ⚠ この変更により、GitHubトークンの管理方法が変わるため、適切なトークンが設定されていることを確認してください。