### PR TITLE
🌟 Terraform Importワークフローの追加と改善

### DIFF
--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -1,0 +1,44 @@
+name: Terraform Import
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'Terraform module name (例: local_workspace_provisioning)'
+        required: true
+        type: string
+      repo:
+        description: 'GitHub repository name (例: local-workspace-provisioning)'
+        required: true
+        type: string
+
+jobs:
+  terraform-import:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::072693953877:role/portfolio-terraform-github-deploy
+          aws-region: ap-northeast-1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Init
+        run: terraform -chdir=./terraform/src/repository init -reconfigure
+
+      - name: Terraform Import (repository, branch_default, actions_repository_permissions, branch_protection)
+        run: |
+          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_repository.this" "${{ github.event.inputs.repo }}"
+          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_default.this" "${{ github.event.inputs.repo }}"
+          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_actions_repository_permissions.this" "${{ github.event.inputs.repo }}"
+          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_protection.this[\"main\"]" "${{ github.event.inputs.repo }}:main"

--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   terraform-import:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -38,6 +38,8 @@ jobs:
         run: terraform -chdir=./terraform/src/repository init -reconfigure
 
       - name: Terraform Import (repository, branch_default, actions_repository_permissions, branch_protection)
+        env:
+          GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
         run: |
           terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_repository.this" "${{ github.event.inputs.repo }}"
           terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_default.this" "${{ github.event.inputs.repo }}:main"

--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Terraform Import (repository, branch_default, actions_repository_permissions, branch_protection)
         run: |
           terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_repository.this" "${{ github.event.inputs.repo }}"
-          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_default.this" "${{ github.event.inputs.repo }}"
+          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_default.this" "${{ github.event.inputs.repo }}:main"
           terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_actions_repository_permissions.this" "${{ github.event.inputs.repo }}"
           terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_protection.this[\"main\"]" "${{ github.event.inputs.repo }}:main"

--- a/terraform/src/repository/update-license-year.tf
+++ b/terraform/src/repository/update-license-year.tf
@@ -1,0 +1,15 @@
+module "update-license-year" {
+  source         = "../../modules/repository"
+  github_token   = var.github_token
+  repository     = "update-license-year"
+  default_branch = "main"
+  topics         = ["license"]
+  description    = "Automatically update license year in repositories."
+  branches_to_protect = {
+    "main" = {
+      required_status_checks        = true
+      required_pull_request_reviews = true
+      status_check_contexts         = ["pre-commit"]
+    }
+  }
+}


### PR DESCRIPTION

## 📒 変更概要

1. ✨ 新しいGitHub Actionsワークフロー「Terraform Import」を追加しました。これにより、Terraformモジュール名とリポジトリ名を入力として受け取り、指定されたリポジトリのTerraformリソースをインポートする機能を提供します。
2. ✨ Terraform Importワークフローに`GITHUB_TOKEN`環境変数を追加し、リポジトリとデフォルトブランチのインポートを行う処理を更新しました。
3. ✨ デフォルトブランチのインポートを「main」に変更しました。
4. ✨ Terraform Importワークフローにタイムアウト設定を追加しました。これにより、ジョブの実行時間が制限され、効率的なリソース管理が可能になります。
5. ✨ 新しいTerraformモジュール「update-license-year」を追加しました。リポジトリのライセンス年を自動的に更新する機能を提供し、保護するブランチの要件を設定しています。

## ⚒ 技術的詳細

1. 🛠️ `.github/workflows/terraform-import.yml`ファイルが新規作成され、Terraform Importワークフローが定義されています。
2. 🛠️ `GITHUB_TOKEN`環境変数が追加され、Terraformのインポート処理で使用されるようになりました。
3. 🛠️ タイムアウト設定が追加され、ワークフローの実行時間が5分に制限されました。
4. 🛠️ `terraform/src/repository/update-license-year.tf`ファイルが新規作成され、ライセンス年を自動更新するTerraformモジュールが定義されています。

## ⚠ 注意点

1. 💡 `GITHUB_TOKEN`は機密情報であるため、適切に管理してください。
2. 💡 タイムアウト設定により、長時間実行されるジョブが中断される可能性がありますので、必要に応じて設定を調整してください。