### PR TITLE
🔧 TerraformワークフローでのGITHUB_TOKENの環境変数名を統一

### DIFF
--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Terraform Import (repository, branch_default, actions_repository_permissions, branch_protection)
         env:
-          GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+          TF_VAR_github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
         run: |
           terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_repository.this" "${{ github.event.inputs.repo }}"
           terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_default.this" "${{ github.event.inputs.repo }}:main"


### PR DESCRIPTION

## 📒 変更概要

- ✨ `terraform-import.yml`ファイル内で、Terraformワークフローにおける環境変数名を`GITHUB_TOKEN`から`TF_VAR_github_token`に変更しました。

## ⚒ 技術的詳細

- 🔄 `.github/workflows/terraform-import.yml`の該当箇所で、環境変数の設定を以下のように変更しました。
  - 変更前: `GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}`
  - 変更後: `TF_VAR_github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}`

## ⚠ 注意点

- 💡 この変更により、Terraformワークフローで使用される環境変数名が統一され、可読性とメンテナンス性が向上します。