### PR TITLE
🌟 Terraform Importワークフローの改善

### DIFF
--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -42,6 +42,6 @@ jobs:
           TF_VAR_github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
         run: |
           terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_repository.this" "${{ github.event.inputs.repo }}"
-          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_default.this" "${{ github.event.inputs.repo }}:main"
+          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_default.this" "${{ github.event.inputs.repo }}"
           terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_actions_repository_permissions.this" "${{ github.event.inputs.repo }}"
           terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_protection.this[\"main\"]" "${{ github.event.inputs.repo }}:main"

--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           TF_VAR_github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
         run: |
-          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_repository.this" "${{ github.event.inputs.repo }}"
-          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_default.this" "${{ github.event.inputs.repo }}"
-          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_actions_repository_permissions.this" "${{ github.event.inputs.repo }}"
-          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_protection.this[\"main\"]" "${{ github.event.inputs.repo }}:main"
+          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_repository.this" "${{ github.event.inputs.repo }}" || true
+          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_default.this" "${{ github.event.inputs.repo }}" || true
+          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_actions_repository_permissions.this" "${{ github.event.inputs.repo }}" || true
+          terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_protection.this[\"main\"]" "${{ github.event.inputs.repo }}:main" || true

--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Terraform Import (repository, branch_default, actions_repository_permissions, branch_protection)
         env:
-          GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+          TF_VAR_github_token: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
         run: |
           terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_repository.this" "${{ github.event.inputs.repo }}"
           terraform -chdir=./terraform/src/repository import "module.${{ github.event.inputs.module }}.github_branch_default.this" "${{ github.event.inputs.repo }}:main"


### PR DESCRIPTION

## 📒 変更概要

- Terraform Importワークフローにおいて、エラーハンドリングを追加し、インポートコマンドが失敗しても処理が継続できるようにしました。
- デフォルトブランチのインポート処理を「main」からリポジトリのデフォルトブランチに変更しました。
- 環境変数の設定を統一するために、`GITHUB_TOKEN`を`TF_VAR_github_token`に変更しました。

## ⚒ 技術的詳細

- `terraform-import.yml`ファイル内の各インポートコマンドに`|| true`を追加し、エラーが発生してもジョブが失敗しないようにしました。
- デフォルトブランチのインポート処理を`${{ github.event.inputs.repo }}:main`から`${{ github.event.inputs.repo }}`に変更しました。
- 環境変数の設定を`TF_VAR_github_token`に統一し、Terraformの実行環境での変数管理を簡素化しました。

## ⚠ 注意点

- 💡 この変更により、インポート処理が失敗してもワークフロー全体が停止しないため、エラーの検知が遅れる可能性があります。エラーログの確認を怠らないようにしてください。