### PR TITLE
🔧 GitHub ActionsでのPAT使用に関するコメントの整形と修正

### DIFF
--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           working-directory: ./terraform/src/repository
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_APPS_TOKEN: ${{ steps.app_token.outputs.token }}
+          GITHUB_APPS_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}  # PAT を使用するように変更
 
       - name: Start Deployment
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           working-directory: ./terraform/src/repository
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_APPS_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}  # PAT を使用するように変更
+          GITHUB_APPS_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }} # PAT を使用するように変更
 
       - name: Start Deployment
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION

## 📒 変更概要

- 🛠️ `.github/workflows/terraform-github.yml` ファイルにおいて、Personal Access Token (PAT) を使用するためのコメントを整形しました。
- 🛠️ `terraform-plan` ステップで、GitHub Apps Token から PAT に変更しました。

## ⚒ 技術的詳細

- 📝 `GITHUB_APPS_TOKEN` の設定において、コメントの整形を行いました。具体的には、コメントの末尾のスペースを削除しました。
- 🔄 `terraform-plan` ステップで、`GITHUB_APPS_TOKEN` の値を `${{ steps.app_token.outputs.token }}` から `${{ secrets.TERRAFORM_GITHUB_TOKEN }}` に変更しました。これにより、GitHub Apps Token ではなく、PAT を使用するようになりました。

## ⚠ 注意点

- 💡 この変更は、GitHub Actions のワークフローに影響を与えるため、適用後に動作確認を行うことを推奨します。