### PR TITLE
🚀 Terraformモジュールからの非推奨の'moved'ブロックの削除

### DIFF
--- a/terraform/src/repository/anime-tweet-bot.tf
+++ b/terraform/src/repository/anime-tweet-bot.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.anime-tweet-bot.github_actions_repository_permissions.this
-  to   = module.anime-tweet-bot.github_actions_repository_permissions.this[0]
-}
-
 module "anime-tweet-bot" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/blender-chat-character.tf
+++ b/terraform/src/repository/blender-chat-character.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.blender-chat-character.github_actions_repository_permissions.this
-  to   = module.blender-chat-character.github_actions_repository_permissions.this[0]
-}
-
 module "blender_chat_character" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/blog.tf
+++ b/terraform/src/repository/blog.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.blog.github_actions_repository_permissions.this
-  to   = module.blog.github_actions_repository_permissions.this[0]
-}
-
 module "blog" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/boilerplate-saas.tf
+++ b/terraform/src/repository/boilerplate-saas.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.boilerplate-saas.github_actions_repository_permissions.this
-  to   = module.boilerplate-saas.github_actions_repository_permissions.this[0]
-}
-
 module "boilerplate-saas" {
   source       = "../../modules/repository"
   github_token = var.github_token

--- a/terraform/src/repository/dotfiles.tf
+++ b/terraform/src/repository/dotfiles.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.dotfiles.github_actions_repository_permissions.this
-  to   = module.dotfiles.github_actions_repository_permissions.this[0]
-}
-
 module "dotfiles" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/local-workspace-provisioning.tf
+++ b/terraform/src/repository/local-workspace-provisioning.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.local-workspace-provisioning.github_actions_repository_permissions.this
-  to   = module.local-workspace-provisioning.github_actions_repository_permissions.this[0]
-}
-
 module "local-workspace-provisioning" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/nana-kana-dialogue-system.tf
+++ b/terraform/src/repository/nana-kana-dialogue-system.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.nana-kana-dialogue-system.github_actions_repository_permissions.this
-  to   = module.nana-kana-dialogue-system.github_actions_repository_permissions.this[0]
-}
-
 module "nana_kana_dialogue_system" {
   source         = "../../modules/repository"
   github_token   = var.github_token

--- a/terraform/src/repository/obsidian-vault.tf
+++ b/terraform/src/repository/obsidian-vault.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.obsidian-vault.github_actions_repository_permissions.this
-  to   = module.obsidian-vault.github_actions_repository_permissions.this[0]
-}
-
 module "obsidian-vault" {
   source                 = "../../modules/repository"
   github_token           = var.github_token

--- a/terraform/src/repository/openai-generate-pr-description.tf
+++ b/terraform/src/repository/openai-generate-pr-description.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.openai-generate-pr-description.github_actions_repository_permissions.this
-  to   = module.openai-generate-pr-description.github_actions_repository_permissions.this[0]
-}
-
 module "openai-generate-pr-description" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/private-dotfiles.tf
+++ b/terraform/src/repository/private-dotfiles.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.private-dotfiles.github_actions_repository_permissions.this
-  to   = module.private-dotfiles.github_actions_repository_permissions.this[0]
-}
-
 module "private-dotfiles" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/renovate-config.tf
+++ b/terraform/src/repository/renovate-config.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.renovate-config.github_actions_repository_permissions.this
-  to   = module.renovate-config.github_actions_repository_permissions.this[0]
-}
-
 module "renovate-config" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/terraform-aws.tf
+++ b/terraform/src/repository/terraform-aws.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.terraform-aws.github_actions_repository_permissions.this
-  to   = module.terraform-aws.github_actions_repository_permissions.this[0]
-}
-
 module "terraform-aws" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/terraform-github.tf
+++ b/terraform/src/repository/terraform-github.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.terraform-github.github_actions_repository_permissions.this
-  to   = module.terraform-github.github_actions_repository_permissions.this[0]
-}
-
 module "terraform-github" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/terraform-vercel.tf
+++ b/terraform/src/repository/terraform-vercel.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.terraform-vercel.github_actions_repository_permissions.this
-  to   = module.terraform-vercel.github_actions_repository_permissions.this[0]
-}
-
 module "terraform-vercel" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/time-capsule.tf
+++ b/terraform/src/repository/time-capsule.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.time-capsule.github_actions_repository_permissions.this
-  to   = module.time-capsule.github_actions_repository_permissions.this[0]
-}
-
 module "time-capsule" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/tqer39.tf
+++ b/terraform/src/repository/tqer39.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.tqer39.github_actions_repository_permissions.this
-  to   = module.tqer39.github_actions_repository_permissions.this[0]
-}
-
 module "tqer39" {
   source              = "../../modules/repository"
   github_token        = var.github_token

--- a/terraform/src/repository/update-license-year.tf
+++ b/terraform/src/repository/update-license-year.tf
@@ -1,8 +1,3 @@
-moved {
-  from = module.update-license-year.github_actions_repository_permissions.this
-  to   = module.update-license-year.github_actions_repository_permissions.this[0]
-}
-
 module "update-license-year" {
   source              = "../../modules/repository"
   github_token        = var.github_token


### PR DESCRIPTION

## 📒 変更概要

- 各Terraformモジュールファイルから非推奨の`moved`ブロックを削除しました。
  - 対象ファイル:
    - `anime-tweet-bot.tf`
    - `blender-chat-character.tf`
    - `blog.tf`
    - `boilerplate-saas.tf`
    - `dotfiles.tf`
    - `local-workspace-provisioning.tf`
    - `nana-kana-dialogue-system.tf`
    - `obsidian-vault.tf`
    - `openai-generate-pr-description.tf`
    - `private-dotfiles.tf`
    - `renovate-config.tf`
    - `terraform-aws.tf`
    - `terraform-github.tf`
    - `terraform-vercel.tf`
    - `time-capsule.tf`
    - `tqer39.tf`
    - `update-license-year.tf`

## ⚒ 技術的詳細

- 各モジュールファイルの先頭に存在していた`moved`ブロックを削除しました。
- `moved`ブロックは、モジュールのリソースの移動を示すために使用されていましたが、現在は不要と判断され削除されました。

## ⚠ 注意点

- 💡 この変更は、Terraformの動作に影響を与えないはずですが、念のため適用後の動作確認を推奨します。