### PR TITLE
🚀 モジュール名をed-gamesからmathquestに変更し、参照を更新

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,7 @@
     "kentaro",
     "linuxbrew",
     "markdownlint",
+    "mathquest",
     "nana",
     "nextjs",
     "nodenv",

--- a/terraform/src/repository/mathquest.tf
+++ b/terraform/src/repository/mathquest.tf
@@ -1,8 +1,8 @@
-module "ed-games" {
+module "mathquest" {
   source       = "../../modules/repository"
   github_token = var.github_token
 
-  repository          = "ed-games"
+  repository          = "mathquest"
   owner               = "tqer39"
   default_branch      = "main"
   enable_owner_bypass = true

--- a/terraform/src/repository/terraform.tf
+++ b/terraform/src/repository/terraform.tf
@@ -205,6 +205,19 @@ moved {
   to   = module.private-dotfiles.github_branch_protection.this["main"]
 }
 
+moved {
+  from = module.ed-games.github_repository.this_from_template[0]
+  to   = module.mathquest.github_repository.this_from_template[0]
+}
+moved {
+  from = module.ed-games.github_branch_default.this
+  to   = module.mathquest.github_branch_default.this
+}
+moved {
+  from = module.ed-games.github_repository_ruleset.this["main"]
+  to   = module.mathquest.github_repository_ruleset.this["main"]
+}
+
 # Move addresses after splitting github_repository into count-based resources
 moved {
   from = module.anime-tweet-bot.github_repository.this


### PR DESCRIPTION

## 📒 変更概要

- 🔄 モジュール名を`ed-games`から`mathquest`に変更しました。
- 📚 参照されているファイルや設定をすべて更新しました。

## ⚒ 技術的詳細

- 📂 `terraform/src/repository/ed-games.tf`を`terraform/src/repository/mathquest.tf`にリネームしました。
- 🔧 モジュール名を`module "ed-games"`から`module "mathquest"`に変更しました。
- 🔄 `repository`の名前を`"ed-games"`から`"mathquest"`に変更しました。
- 🔄 `cspell.json`に`"mathquest"`を追加しました。
- 🔀 `terraform/src/repository/terraform.tf`内で、`module.ed-games`から`module.mathquest`への参照を更新しました。

## ⚠ 注意点

- 💡 この変更は、モジュール名とその参照に関するものであり、機能的な変更は含まれていませんが、参照の更新が漏れていないか確認が必要です。