### PR TITLE
Add pre-commit status check to mathquest

### DIFF
--- a/terraform/src/repository/mathquest.tf
+++ b/terraform/src/repository/mathquest.tf
@@ -31,6 +31,14 @@ module "mathquest" {
           required_approving_review_count   = 1
           required_review_thread_resolution = true
         }
+        required_status_checks = {
+          required_check = [
+            {
+              context = "pre-commit"
+            }
+          ]
+          strict_required_status_checks_policy = true
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- add the `pre-commit` job to the mathquest repository ruleset so it is required in PR status checks

## Testing
- not run (terraform CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e04f51ba6c8321bfcfa83f68f04c31