### PR TITLE
🚀 GitHubリポジトリルールセットのステータスチェックルールの設定を改善

### DIFF
--- a/terraform/modules/repository/github_repository_ruleset.tf
+++ b/terraform/modules/repository/github_repository_ruleset.tf
@@ -27,16 +27,28 @@ resource "github_repository_ruleset" "this" {
 
     # Require status checks
     dynamic "required_status_checks" {
-      for_each = try(each.value.rules.required_status_checks, null) != null && length(try(each.value.rules.required_status_checks.required_checks, [])) > 0 ? [each.value.rules.required_status_checks] : []
+      for_each = try(each.value.rules.required_status_checks, null) != null && length(try(
+        each.value.rules.required_status_checks.required_checks,
+        each.value.rules.required_status_checks.required_check,
+        []
+      )) > 0 ? [each.value.rules.required_status_checks] : []
       content {
         dynamic "required_check" {
-          for_each = try(required_status_checks.value.required_checks, [])
+          for_each = try(
+            required_status_checks.value.required_checks,
+            required_status_checks.value.required_check,
+            []
+          )
           content {
             context        = required_check.value.context
             integration_id = try(required_check.value.integration_id, null)
           }
         }
-        strict_required_status_checks_policy = try(required_status_checks.value.strict, true)
+        strict_required_status_checks_policy = try(
+          required_status_checks.value.strict,
+          required_status_checks.value.strict_required_status_checks_policy,
+          true
+        )
       }
     }
 


### PR DESCRIPTION

## 📒 変更概要

- 💡 `github_repository_ruleset.tf`ファイルにおいて、ステータスチェックルールの設定を柔軟に対応できるように修正しました。
- 💡 `required_checks`と`required_check`の両方のバリエーションに対応するようにロジックを拡張しました。

## ⚒ 技術的詳細

- 🔧 `for_each`の条件式を修正し、`required_checks`と`required_check`のいずれかが存在する場合に対応するようにしました。
- 🔧 `strict_required_status_checks_policy`の設定においても、`strict`と`strict_required_status_checks_policy`の両方のバリエーションを考慮するようにしました。

## ⚠ 注意点

- ⚠️ この変更は、ステータスチェックルールの設定に影響を与える可能性があります。設定が正しく適用されているか確認してください。