### PR TITLE
必須ステータスチェックを `workflow-result` に集約する変更

### DIFF
--- a/terraform/src/repositories/dotfiles/main.tf
+++ b/terraform/src/repositories/dotfiles/main.tf
@@ -27,9 +27,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             { context = "prek" },
-            { context = "Minimal - ubuntu-latest" },
-            { context = "Minimal - macos-latest" },
-            { context = "Minimal - Windows" },
+            { context = "workflow-result" },
           ]
           strict_required_status_checks_policy = true
         }

--- a/terraform/src/repositories/dotfiles/main.tf
+++ b/terraform/src/repositories/dotfiles/main.tf
@@ -24,6 +24,15 @@ module "this" {
           required_approving_review_count   = 1
           required_review_thread_resolution = true
         }
+        required_status_checks = {
+          required_check = [
+            { context = "prek" },
+            { context = "Minimal - ubuntu-latest" },
+            { context = "Minimal - macos-latest" },
+            { context = "Minimal - Windows" },
+          ]
+          strict_required_status_checks_policy = true
+        }
       }
     }
   }


### PR DESCRIPTION

## 📒 変更の概要

- 🔧 `terraform/src/repositories/dotfiles/main.tf` において、必須ステータスチェックを `workflow-result` に集約しました。
- ✨ 以前は複数のチェック（`Minimal - ubuntu-latest`, `Minimal - macos-latest`, `Minimal - Windows`）が必要でしたが、これらを一つのチェックに統合しました。

## ⚒ 技術的詳細

- 🔄 `required_status_checks` セクションが更新され、以下のように変更されました：
  - 旧: 
    ```hcl
    required_check = [
      { context = "prek" },
      { context = "Minimal - ubuntu-latest" },
      { context = "Minimal - macos-latest" },
      { context = "Minimal - Windows" },
    ]
    ```
  - 新:
    ```hcl
    required_check = [
      { context = "prek" },
      { context = "workflow-result" },
    ]
    ```

## ⚠ 注意点

- ⚠️ この変更により、以前の個別のチェックが不要になり、`workflow-result` の結果に依存することになります。これにより、CI/CD パイプラインの動作が変更される可能性があるため、十分なテストを行うことをお勧めします。