### PR TITLE
🚫 不要な automerge 設定の削除

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,8 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>tqer39/renovate-config"
-  ],
-  "platformAutomerge": true,
-  "automerge": true,
-  "automergeType": "pr"
+  ]
 }


### PR DESCRIPTION

このプルリクエストでは、`renovate.json5` ファイルから不要な automerge 設定を削除しました。

## 📒 変更の概要

- `renovate.json5` から以下の設定を削除しました:
  - `platformAutomerge`
  - `automerge`
  - `automergeType`

## ⚒ 技術的詳細

- `renovate.json5` の設定を整理し、不要なオプションを削除することで、設定ファイルの可読性を向上させました。

## ⚠ 注意点

- この変更により、automerge 機能が無効になりますので、手動でのマージが必要になります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automerge configuration for Renovate, requiring manual approval for dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->