### PR TITLE
🔧 PRステータスチェックコンテキストを変更

### DIFF
--- a/terraform/src/repositories/claude-code-marketplace/main.tf
+++ b/terraform/src/repositories/claude-code-marketplace/main.tf
@@ -27,7 +27,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "prek"
+              context = "lint"
             }
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/dotfiles/main.tf
+++ b/terraform/src/repositories/dotfiles/main.tf
@@ -27,7 +27,7 @@ module "this" {
         }
         required_status_checks = {
           required_check = [
-            { context = "prek" },
+            { context = "lint" },
             { context = "workflow-result" },
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/edu-quest/main.tf
+++ b/terraform/src/repositories/edu-quest/main.tf
@@ -45,7 +45,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "prek"
+              context = "lint"
             }
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/generate-pr-description/main.tf
+++ b/terraform/src/repositories/generate-pr-description/main.tf
@@ -27,7 +27,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "prek"
+              context = "lint"
             }
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/renovate-config/main.tf
+++ b/terraform/src/repositories/renovate-config/main.tf
@@ -27,7 +27,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "prek"
+              context = "lint"
             }
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/xtrade/main.tf
+++ b/terraform/src/repositories/xtrade/main.tf
@@ -39,7 +39,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "prek"
+              context = "lint"
             }
           ]
           strict_required_status_checks_policy = true


### PR DESCRIPTION

## 📒 変更の概要

- `terraform/src/repositories/claude-code-marketplace/main.tf`、`terraform/src/repositories/dotfiles/main.tf`、`terraform/src/repositories/edu-quest/main.tf`、`terraform/src/repositories/generate-pr-description/main.tf`、`terraform/src/repositories/renovate-config/main.tf`、`terraform/src/repositories/xtrade/main.tf` の各ファイルにおいて、ステータスチェックのコンテキストを `prek` から `lint` に変更しました。

## ⚒ 技術的詳細

- 各ファイルの `required_status_checks` セクション内で、`context` の値を `prek` から `lint` に変更しました。これにより、CI/CDパイプラインでのチェックが `lint` に基づいて行われるようになります。

## ⚠ 注意点

- 💡 この変更により、既存の `prek` チェックが無効になり、代わりに `lint` チェックが必要になります。CI/CDの設定が正しく行われていることを確認してください。