### PR TITLE
🔧 PRステータスチェックコンテキストを`workflow-result`に統一

### DIFF
--- a/terraform/src/repositories/claude-code-marketplace/main.tf
+++ b/terraform/src/repositories/claude-code-marketplace/main.tf
@@ -27,7 +27,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "lint"
+              context = "workflow-result"
             }
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/dotfiles/main.tf
+++ b/terraform/src/repositories/dotfiles/main.tf
@@ -27,8 +27,9 @@ module "this" {
         }
         required_status_checks = {
           required_check = [
-            { context = "lint" },
-            { context = "workflow-result" },
+            {
+              context = "workflow-result"
+            }
           ]
           strict_required_status_checks_policy = true
         }

--- a/terraform/src/repositories/edu-quest/main.tf
+++ b/terraform/src/repositories/edu-quest/main.tf
@@ -45,7 +45,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "lint"
+              context = "workflow-result"
             }
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/generate-pr-description/main.tf
+++ b/terraform/src/repositories/generate-pr-description/main.tf
@@ -27,7 +27,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "lint"
+              context = "workflow-result"
             }
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/notifications/main.tf
+++ b/terraform/src/repositories/notifications/main.tf
@@ -28,7 +28,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "pre-commit"
+              context = "workflow-result"
             }
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/renovate-config/main.tf
+++ b/terraform/src/repositories/renovate-config/main.tf
@@ -27,7 +27,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "lint"
+              context = "workflow-result"
             }
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/terraform-aws/main.tf
+++ b/terraform/src/repositories/terraform-aws/main.tf
@@ -27,16 +27,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "pre-commit"
-            },
-            {
-              context = "terraform-aws-management"
-            },
-            {
-              context = "terraform-aws-portfolio"
-            },
-            {
-              context = "terraform-aws-sandbox"
+              context = "workflow-result"
             }
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/time-capsule/main.tf
+++ b/terraform/src/repositories/time-capsule/main.tf
@@ -27,7 +27,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "pre-commit"
+              context = "workflow-result"
             }
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/update-license-year/main.tf
+++ b/terraform/src/repositories/update-license-year/main.tf
@@ -27,7 +27,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "pre-commit"
+              context = "workflow-result"
             }
           ]
           strict_required_status_checks_policy = true

--- a/terraform/src/repositories/xtrade/main.tf
+++ b/terraform/src/repositories/xtrade/main.tf
@@ -39,7 +39,7 @@ module "this" {
         required_status_checks = {
           required_check = [
             {
-              context = "lint"
+              context = "workflow-result"
             }
           ]
           strict_required_status_checks_policy = true


### PR DESCRIPTION

## 📒 変更の概要

- `terraform/src/repositories`内の複数の`main.tf`ファイルにおいて、ステータスチェックのコンテキストを`lint`や`pre-commit`から`workflow-result`に変更しました。

## ⚒ 技術的詳細

- 変更されたファイル:
  - `terraform/src/repositories/claude-code-marketplace/main.tf`
  - `terraform/src/repositories/dotfiles/main.tf`
  - `terraform/src/repositories/edu-quest/main.tf`
  - `terraform/src/repositories/generate-pr-description/main.tf`
  - `terraform/src/repositories/notifications/main.tf`
  - `terraform/src/repositories/renovate-config/main.tf`
  - `terraform/src/repositories/terraform-aws/main.tf`
  - `terraform/src/repositories/time-capsule/main.tf`
  - `terraform/src/repositories/update-license-year/main.tf`
  - `terraform/src/repositories/xtrade/main.tf`

- 各ファイル内で、`required_status_checks`の`required_check`リストに含まれるコンテキストが変更されました。これにより、ワークフローの結果に基づくチェックが統一され、より一貫性のあるCI/CDプロセスが実現されます。

## ⚠ 注意点

- 変更により、以前の`lint`や`pre-commit`チェックが無効化されるため、これらのチェックを必要とするプロジェクトでは、別途対応が必要です。