### PR TITLE
✨ workout-tracker リポジトリを Terraform 管理に追加

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -60,6 +60,8 @@ shellcheck
 shellenv
 SIGPIPE
 SSIA
+swiftdata
+swiftui
 Takeru
 textlint
 textlintcache

--- a/docs/superpowers/plans/2026-04-20-workout-tracker-repo.md
+++ b/docs/superpowers/plans/2026-04-20-workout-tracker-repo.md
@@ -1,0 +1,253 @@
+# workout-tracker リポジトリ追加 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新規リポジトリ `tqer39/workout-tracker`（iOS 筋トレ記録アプリ）を Terraform で管理できるようにする。
+
+**Architecture:** `terraform/src/repositories/workout-tracker/` ディレクトリを新設し、既存 `edu-quest` / `xtrade` と同じ 5 ファイル構成（main.tf / variables.tf / providers.tf / terraform.tf / outputs.tf）で `../../../modules/repository` を呼び出す。モジュールデフォルトの main ブランチ保護を適用する（`disable_default_main_protection` は指定しない）。
+
+**Tech Stack:** Terraform 1.14.8, integrations/github 6.11.1, S3 backend（ap-northeast-1）, lefthook/pre-commit, cspell, textlint, markdownlint, tflint
+
+**Spec:** `docs/superpowers/specs/2026-04-20-workout-tracker-repo-design.md`
+
+---
+
+## File Structure
+
+新規作成:
+
+- `terraform/src/repositories/workout-tracker/main.tf` — モジュール呼び出し（リポジトリ本体定義）
+- `terraform/src/repositories/workout-tracker/variables.tf` — `github_token` 入力変数
+- `terraform/src/repositories/workout-tracker/providers.tf` — GitHub プロバイダ設定
+- `terraform/src/repositories/workout-tracker/terraform.tf` — required_version / required_providers / S3 backend
+- `terraform/src/repositories/workout-tracker/outputs.tf` — 現状出力なし（コメントのみ）
+
+`.terraform.lock.hcl` は `terraform init` で自動生成されるため手書きしない。
+
+変更なし（既存ワークフローが `terraform/src/repositories/*` をマトリックスで自動検出するため、CI 側の変更は不要）。
+
+---
+
+## Task 1: terraform.tf を作成
+
+**Files:**
+
+- Create: `terraform/src/repositories/workout-tracker/terraform.tf`
+
+- [ ] **Step 1: ディレクトリとファイルを作成**
+
+```hcl
+terraform {
+  required_version = "1.14.8"
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "6.11.1"
+    }
+  }
+  backend "s3" {
+    bucket  = "terraform-tfstate-tqer39-072693953877-ap-northeast-1"
+    key     = "terraform-github/repositories/workout-tracker.tfstate"
+    region  = "ap-northeast-1"
+    encrypt = true
+  }
+}
+```
+
+既存 `terraform/src/repositories/edu-quest/terraform.tf` と同一構造、`key` のみ `workout-tracker.tfstate` に差し替え。
+
+---
+
+## Task 2: providers.tf を作成
+
+**Files:**
+
+- Create: `terraform/src/repositories/workout-tracker/providers.tf`
+
+- [ ] **Step 1: ファイル作成**
+
+```hcl
+provider "github" {
+  owner = "tqer39"
+  token = var.github_token
+}
+```
+
+---
+
+## Task 3: variables.tf を作成
+
+**Files:**
+
+- Create: `terraform/src/repositories/workout-tracker/variables.tf`
+
+- [ ] **Step 1: ファイル作成**
+
+```hcl
+variable "github_token" {
+  type        = string
+  description = "GitHub token"
+  sensitive   = true
+}
+```
+
+---
+
+## Task 4: outputs.tf を作成
+
+**Files:**
+
+- Create: `terraform/src/repositories/workout-tracker/outputs.tf`
+
+- [ ] **Step 1: ファイル作成**
+
+```hcl
+# Outputs can be added here if needed
+```
+
+---
+
+## Task 5: main.tf を作成
+
+**Files:**
+
+- Create: `terraform/src/repositories/workout-tracker/main.tf`
+
+- [ ] **Step 1: ファイル作成**
+
+```hcl
+module "this" {
+  source       = "../../../modules/repository"
+  github_token = var.github_token
+
+  repository          = "workout-tracker"
+  owner               = "tqer39"
+  default_branch      = "main"
+  enable_owner_bypass = true
+  description         = "iOS app for registering workout menus and recording training sessions, built with Swift and SwiftUI."
+  topics = [
+    "swift",
+    "swiftui",
+    "ios",
+    "workout",
+    "fitness",
+    "swiftdata",
+    "training-log",
+  ]
+}
+```
+
+設計原則:
+
+- `disable_default_main_protection` は指定しない（新規 repo なのでモジュールデフォルトの main 保護を最初から適用）
+- `branch_rulesets` ブロックも書かない（モジュールデフォルトに委ねる）
+- `template_*` も指定しない（空リポジトリから Xcode で作成）
+- `configure_actions_permissions` も指定しない（モジュールデフォルト）
+
+---
+
+## Task 6: フォーマット
+
+- [ ] **Step 1: terraform fmt**
+
+Run: `just fmt`
+Expected: 差分なし（すでに正しい形式で書いているため）、もしくは最小限の整形差分のみ
+
+---
+
+## Task 7: Terraform 初期化と検証
+
+**Files:**
+
+- Auto-create: `terraform/src/repositories/workout-tracker/.terraform.lock.hcl`
+
+- [ ] **Step 1: terraform init**
+
+Run: `cd terraform/src/repositories/workout-tracker && terraform init`
+Expected: `Terraform has been successfully initialized!` と表示され、`.terraform.lock.hcl` が生成される
+
+- [ ] **Step 2: terraform validate**
+
+Run: `cd terraform/src/repositories/workout-tracker && terraform validate`
+Expected: `Success! The configuration is valid.`
+
+- [ ] **Step 3: terraform plan（可能であれば）**
+
+Run: `cd terraform/src/repositories/workout-tracker && terraform plan`
+Expected: `module.this.github_repository.this` を含む複数リソースが `will be created` として表示される。
+Note: AWS 認証 / GITHUB_TOKEN が無い場合はこの手順をスキップし、コメントで「ローカル環境に認証情報がないため CI の plan に委ねる」と記録する。
+
+---
+
+## Task 8: pre-commit / lefthook での検証
+
+- [ ] **Step 1: lefthook run**
+
+Run: `just lint`
+Expected: すべて ✅（`terraform-fmt`, `cspell`, `markdownlint`, `textlint`, `betterleaks`, `yamllint`, `actionlint` 等）
+
+cspell が `swiftui` / `swiftdata` 等について警告した場合は `.cspell/project-words.txt` に追加（spec 執筆時に追加済みなので本来不要）。
+
+---
+
+## Task 9: コミット
+
+- [ ] **Step 1: 追加ファイルをステージング**
+
+Run:
+
+```bash
+git add terraform/src/repositories/workout-tracker/main.tf \
+        terraform/src/repositories/workout-tracker/variables.tf \
+        terraform/src/repositories/workout-tracker/providers.tf \
+        terraform/src/repositories/workout-tracker/terraform.tf \
+        terraform/src/repositories/workout-tracker/outputs.tf \
+        terraform/src/repositories/workout-tracker/.terraform.lock.hcl
+```
+
+- [ ] **Step 2: コミット**
+
+Run:
+
+```bash
+git commit -m "$(cat <<'EOF'
+✨ workout-tracker リポジトリを Terraform 管理に追加
+
+iOS 筋トレ記録アプリ用の GitHub リポジトリを新規追加。
+Swift + SwiftUI 構成、ローカル完結（SwiftData/CoreData）を想定。
+モジュールデフォルトの main ブランチ保護を適用。
+EOF
+)"
+```
+
+Expected: pre-commit フックが全項目 ✅ を返し commit 成功。
+
+---
+
+## Task 10: ブランチ push と PR 作成
+
+- [ ] **Step 1: push**
+
+Run: `git push -u origin <current-branch>`
+Expected: push 成功、CI 側で `terraform-github.yml` の matrix が `workout-tracker` を検出して plan を実行
+
+- [ ] **Step 2: PR 作成**
+
+Run: `gh pr create --title "✨ workout-tracker リポジトリを Terraform 管理に追加" --body "..."`
+Body には以下を含める:
+
+- 概要: iOS 筋トレ記録アプリ用リポジトリ追加
+- 設計ドキュメントへのリンク: `docs/superpowers/specs/2026-04-20-workout-tracker-repo-design.md`
+- スタック: Swift + SwiftUI, ローカル完結
+- CI の `terraform plan` 出力が `github_repository workout-tracker` の create プランを含むことを確認
+
+Expected: PR URL が返ってくる。CI の `workflow-result` が緑になったらマージ可能。
+
+---
+
+## Self-Review Checklist（書き手が記入済み）
+
+- [x] Spec の「ファイル構成」「main.tf の主要パラメータ」「検証」要件を Task 1-8 が網羅
+- [x] Placeholder（TBD / TODO / "あとで"）無し
+- [x] 型・パラメータ名一貫性（`workout-tracker` / `training-log` / `swiftdata` が全 Task で一致）
+- [x] 各 Task は 2-5 分で完了可能な粒度

--- a/docs/superpowers/specs/2026-04-20-workout-tracker-repo-design.md
+++ b/docs/superpowers/specs/2026-04-20-workout-tracker-repo-design.md
@@ -1,0 +1,78 @@
+# workout-tracker リポジトリ追加設計
+
+## 概要
+
+筋トレメニューの登録と実施記録を行う iOS アプリ (`tqer39/workout-tracker`) の GitHub リポジトリを Terraform で管理する。既存の `terraform/src/repositories/<repo>/` パターンに従い、1 リポジトリ 1 ディレクトリ構成で追加する。
+
+## 要件
+
+| 項目 | 値 |
+| --- | --- |
+| リポジトリ名 | `workout-tracker` |
+| owner | `tqer39` |
+| visibility | Public |
+| description | `iOS app for registering workout menus and recording training sessions, built with Swift and SwiftUI.` |
+| default_branch | `main` |
+| topics | `swift`, `swiftui`, `ios`, `workout`, `fitness`, `swiftdata`, `training-log` |
+| template | なし（空リポジトリから Xcode で作成） |
+| enable_owner_bypass | `true` |
+| configure_actions_permissions | 指定しない（モジュールデフォルト） |
+| main ブランチ保護 | モジュールデフォルト（force push 禁止・削除禁止・PR 必須・linear history・`workflow-result` 必須・承認 0・所有者 bypass） |
+
+## アプリ仕様（参考・今回のリポジトリ管理スコープ外）
+
+- プラットフォーム: iOS（Swift + SwiftUI）
+- バックエンド: なし。端末ローカルで完結（SwiftData または Core Data を採用）
+- クラウド同期は現状スコープ外
+
+本 spec は Terraform による GitHub リポジトリ管理のみを対象とし、アプリ実装は別プロジェクト（新リポジトリ内）で扱う。
+
+## ファイル構成
+
+既存 repo の定型に合わせ、`terraform/src/repositories/workout-tracker/` 配下に以下の 5 ファイルを新規追加する。
+
+- `main.tf`: `../../../modules/repository` を呼び出す
+- `variables.tf`: `github_token` 変数定義
+- `providers.tf`: `github` プロバイダ設定
+- `terraform.tf`: required_version / required_providers / S3 backend（key は `terraform-github/repositories/workout-tracker.tfstate`）
+- `outputs.tf`: 現時点で出力なし（プレースホルダーコメント）
+
+`.terraform.lock.hcl` は `terraform init` によって自動生成されるため、手書きしない。
+
+## main.tf の主要パラメータ
+
+```hcl
+module "this" {
+  source       = "../../../modules/repository"
+  github_token = var.github_token
+
+  repository     = "workout-tracker"
+  owner          = "tqer39"
+  default_branch = "main"
+  enable_owner_bypass = true
+  description    = "iOS app for registering workout menus and recording training sessions, built with Swift and SwiftUI."
+  topics = [
+    "swift",
+    "swiftui",
+    "ios",
+    "workout",
+    "fitness",
+    "swiftdata",
+    "training-log",
+  ]
+}
+```
+
+`disable_default_main_protection` は指定しない（標準保護を新規段階から適用）。`branch_rulesets` ブロックも書かず、モジュールデフォルトに委ねる。`template_*` も指定しない。
+
+## 検証
+
+- `just fmt` で HCL フォーマット
+- `just validate` で構文検証
+- `just plan` で新規 repo が作成計画に載ることを確認（`workout-tracker` の `github_repository` が add で表示される）
+
+## 非スコープ
+
+- iOS アプリ本体の実装
+- CI/CD ワークフロー（後続 PR で追加）
+- Xcode プロジェクト初期化

--- a/terraform/src/repositories/workout-tracker/.terraform.lock.hcl
+++ b/terraform/src/repositories/workout-tracker/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.11.1"
+  constraints = "6.11.1"
+  hashes = [
+    "h1:Hqvebe3Zc19DxRCHHLIByBvxCm+WJqGyAyYCbJDuHGE=",
+    "h1:R8JcD0DYjcbIE6HDDvBc/viZhXzQNTSjsqztG1qKpSU=",
+    "h1:dUQg8y5FcYb063ZboAkmgpgQvNb6wqR8uDBJPZnpJEM=",
+    "h1:nanzeesukYMHAFrSaq7rnWx7iRDHMpme5KzQI3m/ZZo=",
+    "h1:qIQdb31z+C7Ufnzc7GSTB5Na1bKqY+Mr+zIvSEmKZBs=",
+    "zh:0a5262b033a30d8a77ebf844dc3afd7e726d5f53ac1c9d4072cf9157820d1f73",
+    "zh:437236181326f92d1a7c56985b2ac3223efd73f75c528323b90f4b7d1b781090",
+    "zh:49a12c14d1d3a143a124ba81f15fbf18714af90752c993698c76e84fa85da004",
+    "zh:61eaf17b559a26ca14deb597375a6678d054d739e8b81c586ef1d0391c307916",
+    "zh:7f3f1e2c36f4787ca9a5aeb5317b8c3f6cc652368d1f8f00fb80f404109d4db1",
+    "zh:85a232f2e96e5adafa2676f38a96b8cc074e96f715caf6ee1d169431174897d2",
+    "zh:979d005af2a9003d887413195948c899e9f5aba4a79cce1eed40f3ba50301af1",
+    "zh:b8c8cd3254504d2184d2b2233ad41b5fdfda91a36fc864926cbc5c7eee1bfea3",
+    "zh:d00959e62930fb75d2b97c1d66ab0143120541d5a1b3f26d3551f24cb0361f83",
+    "zh:d0b544eed171c7563387fe87f0af3d238bb3804798159b4d0453c97927237daf",
+    "zh:ecfa19b1219aa55b1ece98d8cff5b1494dc0387329c8ae0d8f762ec3871fb75d",
+    "zh:f2c99825f38c92ac599ad36b9d093ea0c0d790fd0c02e861789e14735a605f86",
+    "zh:f33b5abe14ad5fb9978da5dbd3bc6989f69766150d4b30ed283a2c281871eda3",
+    "zh:f6c2fe9dd958c554170dc0c35ca41b60fcc6253304cde0b9941c5c872b18ac54",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/terraform/src/repositories/workout-tracker/main.tf
+++ b/terraform/src/repositories/workout-tracker/main.tf
@@ -1,0 +1,19 @@
+module "this" {
+  source       = "../../../modules/repository"
+  github_token = var.github_token
+
+  repository          = "workout-tracker"
+  owner               = "tqer39"
+  default_branch      = "main"
+  enable_owner_bypass = true
+  description         = "iOS app for registering workout menus and recording training sessions, built with Swift and SwiftUI."
+  topics = [
+    "swift",
+    "swiftui",
+    "ios",
+    "workout",
+    "fitness",
+    "swiftdata",
+    "training-log",
+  ]
+}

--- a/terraform/src/repositories/workout-tracker/outputs.tf
+++ b/terraform/src/repositories/workout-tracker/outputs.tf
@@ -1,0 +1,1 @@
+# Outputs can be added here if needed

--- a/terraform/src/repositories/workout-tracker/providers.tf
+++ b/terraform/src/repositories/workout-tracker/providers.tf
@@ -1,0 +1,4 @@
+provider "github" {
+  owner = "tqer39"
+  token = var.github_token
+}

--- a/terraform/src/repositories/workout-tracker/terraform.tf
+++ b/terraform/src/repositories/workout-tracker/terraform.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = "1.14.8"
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "6.11.1"
+    }
+  }
+  backend "s3" {
+    bucket  = "terraform-tfstate-tqer39-072693953877-ap-northeast-1"
+    key     = "terraform-github/repositories/workout-tracker.tfstate"
+    region  = "ap-northeast-1"
+    encrypt = true
+  }
+}

--- a/terraform/src/repositories/workout-tracker/variables.tf
+++ b/terraform/src/repositories/workout-tracker/variables.tf
@@ -1,0 +1,5 @@
+variable "github_token" {
+  type        = string
+  description = "GitHub token"
+  sensitive   = true
+}


### PR DESCRIPTION

## 📒 変更の概要

- 新規リポジトリ `tqer39/workout-tracker` を Terraform で管理するための設定を追加しました。
- iOS 筋トレ記録アプリ用の GitHub リポジトリを新規作成し、Swift と SwiftUI を使用して構築されることを想定しています。

## ⚒ 技術的詳細

- `terraform/src/repositories/workout-tracker/` ディレクトリを新設し、以下のファイルを追加しました:
  - `main.tf`: リポジトリの定義を行うモジュールを呼び出します。
  - `variables.tf`: GitHub トークンを入力変数として定義します。
  - `providers.tf`: GitHub プロバイダの設定を行います。
  - `terraform.tf`: Terraform のバージョンやプロバイダ、S3 バックエンドの設定を行います。
  - `outputs.tf`: 現時点では出力はありませんが、必要に応じて追加可能です。
- `.terraform.lock.hcl` は `terraform init` によって自動生成されます。

## ⚠ 注意点

- モジュールデフォルトの main ブランチ保護を適用しているため、`disable_default_main_protection` は指定していません。
- CI/CD ワークフローの設定は後続の PR で追加予定です。
- iOS アプリ本体の実装はこの PR のスコープ外です。