### PR TITLE
🔧 terraform-import: ruleset 管理リポジトリで legacy branch_protection import をスキップ

### DIFF
--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -59,7 +59,11 @@ jobs:
           terraform -chdir="${WORKDIR}" import "module.this.github_repository.this[0]" "${REPO}" || true
           terraform -chdir="${WORKDIR}" import "module.this.github_branch_default.this" "${REPO}" || true
           terraform -chdir="${WORKDIR}" import "module.this.github_actions_repository_permissions.this[0]" "${REPO}" || true
-          terraform -chdir="${WORKDIR}" import 'module.this.github_branch_protection.this["main"]' "${REPO}:main" || true
+          if grep -Eq 'disable_default_main_protection[[:space:]]*=[[:space:]]*true' "${WORKDIR}/main.tf"; then
+            echo "Skip github_branch_protection import: ruleset-managed repo (disable_default_main_protection=true)"
+          else
+            terraform -chdir="${WORKDIR}" import 'module.this.github_branch_protection.this["main"]' "${REPO}:main" || true
+          fi
 
       - name: Terraform Import (rulesets)
         env:

--- a/docs/superpowers/plans/2026-04-20-terraform-import-skip-legacy-protection.md
+++ b/docs/superpowers/plans/2026-04-20-terraform-import-skip-legacy-protection.md
@@ -1,0 +1,250 @@
+# terraform-import: ruleset 管理リポジトリでの legacy branch_protection import スキップ 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `.github/workflows/terraform-import.yml` の core resources import step で、`disable_default_main_protection = true` のリポジトリでは `github_branch_protection.this["main"]` の import をスキップし、`Configuration for import target does not exist` エラーのログノイズを解消する。
+
+**Architecture:** 単一ファイル (`.github/workflows/terraform-import.yml`) の 1 step を書き換えるだけ。`grep -Eq` による `main.tf` 内フラグ判定で分岐。
+
+**Tech Stack:** GitHub Actions YAML, Bash, grep, Terraform
+
+**Spec:** `docs/superpowers/specs/2026-04-20-terraform-import-skip-legacy-protection-design.md`
+
+---
+
+## File Structure
+
+- Modify: `.github/workflows/terraform-import.yml` (lines 55-62 付近の `Terraform Import (core resources)` step)
+
+他ファイル変更なし。テストは lint (actionlint / yamllint) と、実リポジトリでの workflow_dispatch 実行で行う。自動テストフレームワークは無い。
+
+---
+
+### Task 1: core resources import step を条件分岐対応に書き換える
+
+**Files:**
+
+- Modify: `.github/workflows/terraform-import.yml:55-62`
+
+- [ ] **Step 1: 現在の step を確認**
+
+Run: `sed -n '55,62p' .github/workflows/terraform-import.yml`
+
+Expected output:
+
+```yaml
+      - name: Terraform Import (core resources)
+        env:
+          TF_VAR_github_token: ${{ steps.app_token.outputs.token }}
+        run: |
+          terraform -chdir="${WORKDIR}" import "module.this.github_repository.this[0]" "${REPO}" || true
+          terraform -chdir="${WORKDIR}" import "module.this.github_branch_default.this" "${REPO}" || true
+          terraform -chdir="${WORKDIR}" import "module.this.github_actions_repository_permissions.this[0]" "${REPO}" || true
+          terraform -chdir="${WORKDIR}" import 'module.this.github_branch_protection.this["main"]' "${REPO}:main" || true
+```
+
+- [ ] **Step 2: step の `run:` ブロックを書き換える**
+
+Edit `.github/workflows/terraform-import.yml` の該当箇所を以下に置き換える:
+
+```yaml
+      - name: Terraform Import (core resources)
+        env:
+          TF_VAR_github_token: ${{ steps.app_token.outputs.token }}
+        run: |
+          terraform -chdir="${WORKDIR}" import "module.this.github_repository.this[0]" "${REPO}" || true
+          terraform -chdir="${WORKDIR}" import "module.this.github_branch_default.this" "${REPO}" || true
+          terraform -chdir="${WORKDIR}" import "module.this.github_actions_repository_permissions.this[0]" "${REPO}" || true
+          if grep -Eq 'disable_default_main_protection[[:space:]]*=[[:space:]]*true' "${WORKDIR}/main.tf"; then
+            echo "Skip github_branch_protection import: ruleset-managed repo (disable_default_main_protection=true)"
+          else
+            terraform -chdir="${WORKDIR}" import 'module.this.github_branch_protection.this["main"]' "${REPO}:main" || true
+          fi
+```
+
+- [ ] **Step 3: 変更を確認**
+
+Run: `sed -n '55,66p' .github/workflows/terraform-import.yml`
+
+Expected: 新しい if/else ブロックが含まれていること。
+
+- [ ] **Step 4: yamllint で構文検証**
+
+Run: `pnpm exec yamllint .github/workflows/terraform-import.yml`
+
+Expected: エラーなし（既存 workflow と同じ指摘レベル以下）。yamllint 未インストール時は `pnpm install` を先に実行。
+
+- [ ] **Step 5: actionlint で workflow 検証**
+
+Run: `pre-commit run actionlint --files .github/workflows/terraform-import.yml || lefthook run pre-commit --files .github/workflows/terraform-import.yml`
+
+または直接:
+
+Run: `actionlint .github/workflows/terraform-import.yml`
+
+Expected: エラーなし。actionlint 未インストール時は `brew install actionlint`。
+
+- [ ] **Step 6: 判定ロジックを手元でドライラン検証**
+
+Run (ruleset-managed case):
+
+```bash
+WORKDIR=./terraform/src/repositories/claude-code-remote
+if grep -Eq 'disable_default_main_protection[[:space:]]*=[[:space:]]*true' "${WORKDIR}/main.tf"; then
+  echo "SKIP"
+else
+  echo "RUN"
+fi
+```
+
+Expected: `SKIP`
+
+Run (legacy-managed case):
+
+```bash
+WORKDIR=./terraform/src/repositories/blog
+if grep -Eq 'disable_default_main_protection[[:space:]]*=[[:space:]]*true' "${WORKDIR}/main.tf"; then
+  echo "SKIP"
+else
+  echo "RUN"
+fi
+```
+
+Expected: `RUN`
+
+（`blog` が存在しない/ `disable_default_main_protection` を含まない場合は `RUN`。存在しないファイルなら grep 自体が失敗し else 側に入る — これは手元検証のみで本番 workflow では `Verify workdir exists` step が既に存在確認済み）
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add .github/workflows/terraform-import.yml
+git commit -m "$(cat <<'EOF'
+🔧 terraform-import: ruleset 管理リポジトリで legacy branch_protection import をスキップ
+
+disable_default_main_protection = true のリポジトリでは
+github_branch_protection リソースが生成されないため、無条件 import で
+"Configuration for import target does not exist" エラーがログに出ていた。
+main.tf を grep してフラグを検知し、該当時は import をスキップする。
+
+Refs: docs/superpowers/specs/2026-04-20-terraform-import-skip-legacy-protection-design.md
+EOF
+)"
+```
+
+Expected: pre-commit hook（cspell, textlint, markdownlint, actionlint, yamllint 等）が全て pass してコミット成功。
+
+---
+
+### Task 2: PR を作成して本番検証
+
+**Files:** なし（GitHub 操作のみ）
+
+- [ ] **Step 1: ブランチを push して PR 作成**
+
+現在のブランチ (`streamed-floating-steele` ベースの worktree) から:
+
+```bash
+git push -u origin HEAD
+gh pr create --title "🔧 terraform-import: ruleset 管理リポジトリで legacy branch_protection import をスキップ" --body "$(cat <<'EOF'
+## Summary
+- run 24635657942 で `claude-code-remote` の import 時に `Configuration for import target does not exist` エラーが出ていた
+- `disable_default_main_protection = true` のリポジトリでは module 側で `github_branch_protection` が生成されないため、無条件 import が失敗する
+- `main.tf` を grep してフラグを検知し、該当時はスキップする
+
+## Test plan
+- [ ] actionlint / yamllint が pass
+- [ ] PR マージ後、`claude-code-remote` に対して workflow_dispatch を実行
+- [ ] ログに "Skip github_branch_protection import" が出て、`Configuration for import target does not exist` が出ないことを確認
+- [ ] `blog` など legacy protection リポジトリで workflow_dispatch し、従来通り branch_protection が import 試行されることを確認
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Refs: docs/superpowers/specs/2026-04-20-terraform-import-skip-legacy-protection-design.md
+EOF
+)"
+```
+
+Expected: PR URL が表示される。
+
+- [ ] **Step 2: CI の完了待ち**
+
+Run: `gh pr checks --watch`
+
+Expected: 全 check が pass。
+
+- [ ] **Step 3: マージ**
+
+ユーザー承認を得てから:
+
+```bash
+gh pr merge --auto --squash
+```
+
+または claude-auto ラベルによる auto-merge を待機。
+
+- [ ] **Step 4: マージ後の動作確認（ruleset 管理リポジトリ）**
+
+main ブランチに反映後:
+
+```bash
+gh workflow run terraform-import.yml -f repo=claude-code-remote
+```
+
+数秒待って最新 run を取得:
+
+```bash
+gh run list --workflow=terraform-import.yml --limit=1 --json databaseId,conclusion,status
+```
+
+完了したら:
+
+```bash
+RUN_ID=$(gh run list --workflow=terraform-import.yml --limit=1 --json databaseId --jq '.[0].databaseId')
+gh run view "$RUN_ID" --log 2>&1 | grep -E "Skip github_branch_protection|Configuration for import target"
+```
+
+Expected:
+
+- `Skip github_branch_protection import: ruleset-managed repo (disable_default_main_protection=true)` が出る
+- `Configuration for import target does not exist` は出ない
+
+- [ ] **Step 5: マージ後の動作確認（legacy 管理リポジトリ、該当があれば）**
+
+`disable_default_main_protection` を指定していないリポジトリが残っていればそれを選び、同様に workflow_dispatch してログで `module.this.github_branch_protection.this["main"]: Importing from ID` が表示されることを確認する。
+
+該当リポジトリが無い場合は Step 5 をスキップ（この場合 step 2 の機能回帰確認は grep ロジックのドライランのみで担保）。
+
+候補調査:
+
+```bash
+grep -L 'disable_default_main_protection *= *true' terraform/src/repositories/*/main.tf
+```
+
+Expected: `disable_default_main_protection = true` を含まない main.tf のリストが出る。
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+- ログエラーの原因特定 → Task 1 Step 2 で if/else により修正
+- ruleset 管理リポジトリで import スキップ → Step 6 でドライラン検証, Step 4 本番検証
+- legacy リポジトリで従来通り動作 → Step 6 ドライラン, Step 5 本番検証
+- ファイル変更: `.github/workflows/terraform-import.yml` のみ → File Structure 明記
+- テスト計画: yamllint / actionlint / 実 workflow_dispatch → Steps 4/5 (lint), Task 2 Steps 4-5 (実行)
+
+**2. Placeholder scan:** TBD / TODO / "implement later" なし。全 step に実行コマンドと期待出力を記載。
+
+**3. Type consistency:** 単一 bash スクリプト内で完結。`WORKDIR` / `REPO` 変数名は既存 workflow と同じ。正規表現 `disable_default_main_protection[[:space:]]*=[[:space:]]*true` は Task 1 Step 2 と Step 6 で一貫。
+
+---
+
+## 実行方式の選択
+
+この計画を実行するには:
+
+1. **Subagent-Driven (推奨)** - タスク毎に fresh subagent 起動
+2. **Inline Execution** - このセッション内で executing-plans を使い実行
+
+Task 数が 2 個と小さいため、inline execution でも十分。

--- a/docs/superpowers/specs/2026-04-20-terraform-import-skip-legacy-protection-design.md
+++ b/docs/superpowers/specs/2026-04-20-terraform-import-skip-legacy-protection-design.md
@@ -1,0 +1,82 @@
+# terraform-import ワークフロー: ruleset 管理リポジトリでの legacy branch_protection import スキップ 設計
+
+## 背景
+
+`terraform-import` ワークフロー ([実行例: run 24635657942](https://github.com/tqer39/terraform-github/actions/runs/24635657942)) は job 全体としては成功するが、`Terraform Import (core resources)` step のログに以下のエラーが記録されている:
+
+```text
+Error: Configuration for import target does not exist
+
+The configuration for the given import module.this.github_branch_protection.this["main"] does not exist.
+All target instances must have an associated configuration to be imported.
+```
+
+該当リポジトリ: `claude-code-remote`（他にも `disable_default_main_protection = true` を指定したリポジトリ全てで同じログが出る）。
+
+## 原因
+
+- `.github/workflows/terraform-import.yml:62` は全リポジトリに対し無条件で `module.this.github_branch_protection.this["main"]` の `terraform import` を実行する
+- 一方 `terraform/src/repositories/claude-code-remote/main.tf` は `disable_default_main_protection = true` を指定し、legacy `github_branch_protection` ではなく `branch_rulesets` (ruleset ベース) で main 保護を行う
+- そのため module 側では `github_branch_protection.this` リソースが `for_each = var.branches_to_protect`（空）で生成されず、import target の config が不在となって terraform が exit 1 する
+- 各 import 行には `|| true` が付いているため step の exit code 自体は 0 になり、job は success となる
+
+## 現状影響
+
+- 機能影響なし（import 自体は他のリソースで成功している）
+- ログノイズとして残り、本物のエラーの見落としリスクがある
+- `disable_default_main_protection = true` を持つリポジトリでは常に発生する
+
+## 目的
+
+ruleset ベースで保護されたリポジトリでは `github_branch_protection` の import を行わず、不要なエラーログを出さない。
+
+## 対象外
+
+- 既存 import 対象（`github_repository` / `github_branch_default` / `github_actions_repository_permissions` / ruleset）のロジック変更
+- エラーメッセージの全面抑制（他の想定外エラーは従来通りログに残す）
+- legacy `github_branch_protection` を残しているリポジトリの ruleset 移行
+
+## 実装方針
+
+`Terraform Import (core resources)` step 内で、`${WORKDIR}/main.tf` に `disable_default_main_protection = true` が含まれる場合のみ branch_protection の import をスキップする。
+
+### 判定方法
+
+`grep -Eq 'disable_default_main_protection[[:space:]]*=[[:space:]]*true' "${WORKDIR}/main.tf"` で判定。
+
+- 対象ファイルは各リポジトリの `main.tf` 固定（現在の repository 別構造に合わせる）
+- 正規表現は `=` 前後の空白を許容
+- 該当時: `echo` でスキップ理由をログに残し、terraform import を実行しない
+- 非該当時: 従来通り `terraform import ... || true` を実行
+
+### 変更差分（抜粋）
+
+```yaml
+- name: Terraform Import (core resources)
+  env:
+    TF_VAR_github_token: ${{ steps.app_token.outputs.token }}
+  run: |
+    terraform -chdir="${WORKDIR}" import "module.this.github_repository.this[0]" "${REPO}" || true
+    terraform -chdir="${WORKDIR}" import "module.this.github_branch_default.this" "${REPO}" || true
+    terraform -chdir="${WORKDIR}" import "module.this.github_actions_repository_permissions.this[0]" "${REPO}" || true
+    if grep -Eq 'disable_default_main_protection[[:space:]]*=[[:space:]]*true' "${WORKDIR}/main.tf"; then
+      echo "Skip github_branch_protection import: ruleset-managed repo (disable_default_main_protection=true)"
+    else
+      terraform -chdir="${WORKDIR}" import 'module.this.github_branch_protection.this["main"]' "${REPO}:main" || true
+    fi
+```
+
+## 変更ファイル
+
+- `.github/workflows/terraform-import.yml` — 該当 step のみ書き換え
+
+## テスト計画
+
+1. `yamllint`（リポジトリ設定の `.yamllint`）と `actionlint`（pre-commit）が通ること
+2. ruleset 管理リポジトリ (`claude-code-remote`) で workflow_dispatch → ログに "Skip github_branch_protection import" が出ること、`Configuration for import target does not exist` が出ないこと
+3. legacy `github_branch_protection` を使うリポジトリ（`disable_default_main_protection` 指定なし、例: `blog`）で workflow_dispatch → 従来通り branch_protection が import 試行されること
+
+## 懸念・留意点
+
+- `main.tf` 以外のファイル（例: 将来的に `repository.tf` へ分割）に `disable_default_main_protection` が書かれるケースは未対応。現時点の全リポジトリは `main.tf` に集約されているため問題ない
+- コメント行 (`# disable_default_main_protection = true`) にもマッチしてしまうが、プロジェクトの運用上そのようなコメントはなく、誤検知時の被害も「import をスキップしてログノイズ削減」に留まるため許容


### PR DESCRIPTION

## 📒 Summary of Changes

- `terraform-import` ワークフローの `.github/workflows/terraform-import.yml` において、`disable_default_main_protection = true` が設定されたリポジトリに対して `github_branch_protection.this["main"]` のインポートをスキップする条件分岐を追加しました。
- 新たに `docs/superpowers/plans/2026-04-20-terraform-import-skip-legacy-protection.md` と `docs/superpowers/specs/2026-04-20-terraform-import-skip-legacy-protection-design.md` を作成し、実装計画と設計を文書化しました。

## ⚒ Technical Details

- `.github/workflows/terraform-import.yml` の `Terraform Import (core resources)` ステップにおいて、`main.tf` ファイル内に `disable_default_main_protection` フラグが存在するかを `grep` コマンドで判定し、該当する場合は `github_branch_protection` のインポートをスキップします。
- 具体的には、以下のようなコードを追加しました。

```yaml
if grep -Eq 'disable_default_main_protection[[:space:]]*=[[:space:]]*true' "${WORKDIR}/main.tf"; then
  echo "Skip github_branch_protection import: ruleset-managed repo (disable_default_main_protection=true)"
else
  terraform -chdir="${WORKDIR}" import 'module.this.github_branch_protection.this["main"]' "${REPO}:main" || true
fi
```

- この変更により、`Configuration for import target does not exist` エラーのログノイズを解消し、よりクリーンなログを実現します。

## ⚠ Points of Caution

- `main.tf` 以外のファイルに `disable_default_main_protection` が記載される場合には未対応です。現在の全リポジトリは `main.tf` にこの設定が集約されているため、問題はありませんが、将来的に構造が変更される可能性があります。
- コメント行にマッチしてしまう可能性がありますが、運用上そのようなコメントは存在しないため、誤検知のリスクは低いと考えています。