### PR TITLE
🚀 ccw-cli リポジトリの追加

### DIFF
--- a/terraform/src/repositories/ccw-cli/.terraform.lock.hcl
+++ b/terraform/src/repositories/ccw-cli/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.11.1"
+  constraints = "6.11.1"
+  hashes = [
+    "h1:nanzeesukYMHAFrSaq7rnWx7iRDHMpme5KzQI3m/ZZo=",
+    "zh:0a5262b033a30d8a77ebf844dc3afd7e726d5f53ac1c9d4072cf9157820d1f73",
+    "zh:437236181326f92d1a7c56985b2ac3223efd73f75c528323b90f4b7d1b781090",
+    "zh:49a12c14d1d3a143a124ba81f15fbf18714af90752c993698c76e84fa85da004",
+    "zh:61eaf17b559a26ca14deb597375a6678d054d739e8b81c586ef1d0391c307916",
+    "zh:7f3f1e2c36f4787ca9a5aeb5317b8c3f6cc652368d1f8f00fb80f404109d4db1",
+    "zh:85a232f2e96e5adafa2676f38a96b8cc074e96f715caf6ee1d169431174897d2",
+    "zh:979d005af2a9003d887413195948c899e9f5aba4a79cce1eed40f3ba50301af1",
+    "zh:b8c8cd3254504d2184d2b2233ad41b5fdfda91a36fc864926cbc5c7eee1bfea3",
+    "zh:d00959e62930fb75d2b97c1d66ab0143120541d5a1b3f26d3551f24cb0361f83",
+    "zh:d0b544eed171c7563387fe87f0af3d238bb3804798159b4d0453c97927237daf",
+    "zh:ecfa19b1219aa55b1ece98d8cff5b1494dc0387329c8ae0d8f762ec3871fb75d",
+    "zh:f2c99825f38c92ac599ad36b9d093ea0c0d790fd0c02e861789e14735a605f86",
+    "zh:f33b5abe14ad5fb9978da5dbd3bc6989f69766150d4b30ed283a2c281871eda3",
+    "zh:f6c2fe9dd958c554170dc0c35ca41b60fcc6253304cde0b9941c5c872b18ac54",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/terraform/src/repositories/ccw-cli/main.tf
+++ b/terraform/src/repositories/ccw-cli/main.tf
@@ -1,0 +1,40 @@
+module "this" {
+  source                          = "../../../modules/repository"
+  github_token                    = var.github_token
+  repository                      = "ccw-cli"
+  owner                           = "tqer39"
+  default_branch                  = "main"
+  enable_owner_bypass             = true
+  disable_default_main_protection = true # TODO: 段階移行後に削除（PR #1555 follow-up）
+  topics                          = ["claude-code", "cli", "git-worktree", "bash"]
+  description                     = "Claude Code worktree launcher with picker & superpowers preamble"
+  visibility                      = "public"
+
+  branch_rulesets = {
+    "main" = {
+      enforcement = "active"
+      conditions = {
+        ref_name = {
+          include = ["~DEFAULT_BRANCH"]
+          exclude = []
+        }
+      }
+      rules = {
+        pull_request = {
+          dismiss_stale_reviews_on_push     = true
+          require_code_owner_review         = false
+          required_approving_review_count   = 1
+          required_review_thread_resolution = true
+        }
+        required_status_checks = {
+          required_check = [
+            {
+              context = "workflow-result"
+            }
+          ]
+          strict_required_status_checks_policy = true
+        }
+      }
+    }
+  }
+}

--- a/terraform/src/repositories/ccw-cli/outputs.tf
+++ b/terraform/src/repositories/ccw-cli/outputs.tf
@@ -1,0 +1,1 @@
+# Outputs can be added here if needed

--- a/terraform/src/repositories/ccw-cli/providers.tf
+++ b/terraform/src/repositories/ccw-cli/providers.tf
@@ -1,0 +1,4 @@
+provider "github" {
+  owner = "tqer39"
+  token = var.github_token
+}

--- a/terraform/src/repositories/ccw-cli/terraform.tf
+++ b/terraform/src/repositories/ccw-cli/terraform.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = "1.14.8"
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "6.11.1"
+    }
+  }
+  backend "s3" {
+    bucket  = "terraform-tfstate-tqer39-072693953877-ap-northeast-1"
+    key     = "terraform-github/repositories/ccw-cli.tfstate"
+    region  = "ap-northeast-1"
+    encrypt = true
+  }
+}

--- a/terraform/src/repositories/ccw-cli/variables.tf
+++ b/terraform/src/repositories/ccw-cli/variables.tf
@@ -1,0 +1,5 @@
+variable "github_token" {
+  type        = string
+  description = "GitHub token"
+  sensitive   = true
+}


### PR DESCRIPTION

## 📒 変更の概要

- 新しいリポジトリ `ccw-cli` を追加しました。
- Terraform 構成ファイルが作成され、GitHub リポジトリの管理が可能になりました。

## ⚒ 技術的詳細

- 新しいディレクトリ `terraform/src/repositories/ccw-cli/` に以下のファイルが追加されました:
  - `main.tf`: GitHub リポジトリの設定を定義するモジュールを含む。
  - `providers.tf`: GitHub プロバイダーの設定。
  - `variables.tf`: GitHub トークンの変数を定義。
  - `outputs.tf`: 出力を追加するためのプレースホルダー。
  - `terraform.tf`: Terraform のバージョンとプロバイダーの設定。
  - `.terraform.lock.hcl`: プロバイダーのバージョン管理ファイル。

- `main.tf` では、リポジトリの詳細（オーナー、デフォルトブランチ、トピックなど）が設定されています。

## ⚠ 注意点

> [!IMPORTANT]
> 
> - `disable_default_main_protection` の設定は、段階移行後に削除される予定です（PR #1555 のフォローアップ）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Infrastructure framework and governance policies for the ccw-cli repository have been established using infrastructure-as-code, including encrypted state management and secure backups, authenticated provider integration, comprehensive branch protection rules requiring pull request reviews and approvals, automatic dismissal of stale reviews upon code changes, and enforced quality assurance through required workflow validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->