### PR TITLE
🚀 JustfileのTerraform初期化ステップを削除

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,8 +25,6 @@ setup:
  @pnpm install --frozen-lockfile
  @echo "→ Installing lefthook git hooks..."
  @lefthook install
- @echo "→ Initializing Terraform..."
- @cd {{terraform_dir}} && terraform init -upgrade
  @echo "✓ Setup complete!"
 
 # Check if required tools are installed


### PR DESCRIPTION

## 📒 変更の概要

- 🗑️ `justfile`から古いTerraform初期化ステップを削除しました。この変更により、セットアッププロセスが簡素化され、不要なコマンドが実行されなくなります。

## ⚒ 技術的詳細

- 🔧 `justfile`の`setup`ターゲットから、以下の行を削除しました:
  ```bash
  @echo "→ Initializing Terraform..."
  @cd {{terraform_dir}} && terraform init -upgrade
  ```
  これにより、Terraformの初期化が自動的に行われなくなります。必要に応じて手動で初期化を行うことができます。

## ⚠ 注意点

- ⚠️ Terraformの初期化を手動で行う必要があるため、プロジェクトのセットアップ時に注意してください。