### PR TITLE
GHA_APP_CLIENT_IDを共通シークレットワークフローに追加

### DIFF
--- a/.github/workflows/set-common-github-secrets.yml
+++ b/.github/workflows/set-common-github-secrets.yml
@@ -26,6 +26,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           GHA_APP_ID: ${{ secrets.GHA_APP_ID }}
+          GHA_APP_CLIENT_ID: ${{ secrets.GHA_APP_CLIENT_ID }}
           GHA_APP_PRIVATE_KEY: ${{ secrets.GHA_APP_PRIVATE_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |

--- a/scripts/set-common-github-secrets.sh
+++ b/scripts/set-common-github-secrets.sh
@@ -18,6 +18,7 @@ for repo in $repos; do
   echo "Setting secret for $repo"
 
   gh secret set GHA_APP_ID --repo "$1/$repo" --body "$GHA_APP_ID"
+  gh secret set GHA_APP_CLIENT_ID --repo "$1/$repo" --body "$GHA_APP_CLIENT_ID"
   gh secret set GHA_APP_PRIVATE_KEY --repo "$1/$repo" --body "$GHA_APP_PRIVATE_KEY"
   gh secret set OPENROUTER_API_KEY --repo "$1/$repo" --body "$OPENROUTER_API_KEY"
 done


### PR DESCRIPTION

## 📒 変更の概要

- ✨ `GHA_APP_CLIENT_ID`を共通シークレットワークフローに追加しました。これにより、GitHub Actionsでのアプリケーションの認証がより簡単になります。

## ⚒ 技術的詳細

- 🔧 `.github/workflows/set-common-github-secrets.yml`ファイルに、`GHA_APP_CLIENT_ID`を環境変数として追加しました。
- 🔧 `scripts/set-common-github-secrets.sh`スクリプトに、各リポジトリに対して`GHA_APP_CLIENT_ID`シークレットを設定するコマンドを追加しました。

## ⚠ 注意点

- ⚠ `GHA_APP_CLIENT_ID`の値が正しく設定されていることを確認してください。誤った値が設定されると、アプリケーションの認証に失敗する可能性があります。