### PR TITLE
🚀 homebrew-tap: App bypass で main ruleset を維持

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -24,6 +24,7 @@ fastapi
 FASTMCP
 frontmatter
 getsentry
+goreleaser
 homelab
 hono
 itkq

--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -6,6 +6,10 @@ inputs:
   GITHUB_TOKEN:
     description: GitHub App トークン
     required: true
+  GHA_APP_ID:
+    description: GitHub App の numeric App ID (一部 repo が ruleset bypass actor 等で利用)
+    required: false
+    default: ""
   working-directory:
     description: Terraform CLI 実行時のパス
     required: true
@@ -18,4 +22,5 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         TF_VAR_github_token: ${{ inputs.GITHUB_TOKEN }}
+        TF_VAR_gha_app_id: ${{ inputs.GHA_APP_ID }}
       shell: bash

--- a/.github/actions/terraform-plan/action.yml
+++ b/.github/actions/terraform-plan/action.yml
@@ -9,6 +9,10 @@ inputs:
   GITHUB_APPS_TOKEN:
     description: GitHub App トークン
     required: true
+  GHA_APP_ID:
+    description: GitHub App の numeric App ID (一部 repo が ruleset bypass actor 等で利用)
+    required: false
+    default: ""
   working-directory:
     description: Terraform CLI 実行時のパス
     required: true
@@ -37,6 +41,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         TF_VAR_github_token: ${{ inputs.GITHUB_APPS_TOKEN }}
+        TF_VAR_gha_app_id: ${{ inputs.GHA_APP_ID }}
       working-directory: ${{ inputs.working-directory }}
       shell: bash
 

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -99,6 +99,7 @@ jobs:
           working-directory: ./terraform/src/repositories/${{ matrix.target }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_APPS_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+          GHA_APP_ID: ${{ secrets.GHA_APP_ID }}
 
       # NOTE: GitHub App では個人アカウントのリポジトリを作成することが仕様上不可能なので PAT を使用する。
       - uses: ./.github/actions/terraform-apply
@@ -106,6 +107,7 @@ jobs:
         with:
           working-directory: ./terraform/src/repositories/${{ matrix.target }}
           GITHUB_TOKEN: ${{ secrets.TERRAFORM_GITHUB_TOKEN }}
+          GHA_APP_ID: ${{ secrets.GHA_APP_ID }}
 
   delete-nochange-comments:
     needs: [set-matrix, terraform]

--- a/terraform/src/repositories/homebrew-tap/main.tf
+++ b/terraform/src/repositories/homebrew-tap/main.tf
@@ -2,15 +2,49 @@ module "this" {
   source       = "../../../modules/repository"
   github_token = var.github_token
 
-  repository          = "homebrew-tap"
-  owner               = "tqer39"
-  default_branch      = "main"
-  enable_owner_bypass = true
-  description         = "Homebrew tap for tqer39 tools (ccw-cli など)"
-  visibility          = "public"
+  repository                      = "homebrew-tap"
+  owner                           = "tqer39"
+  default_branch                  = "main"
+  enable_owner_bypass             = true
+  disable_default_main_protection = true # 下の branch_rulesets["main"] でカスタム定義するため
+  description                     = "Homebrew tap for tqer39 tools (ccw-cli など)"
+  visibility                      = "public"
   topics = [
     "homebrew",
     "homebrew-tap",
     "formula",
   ]
+
+  # goreleaser (GitHub App) が Formula/*.rb を直接 push できるように
+  # App を bypass actor に登録したカスタム main 保護を定義する。
+  # required_status_checks は tap に CI が無いので外す。
+  branch_rulesets = {
+    "main" = {
+      enforcement = "active"
+      conditions = {
+        ref_name = {
+          include = ["~DEFAULT_BRANCH"]
+          exclude = []
+        }
+      }
+      rules = {
+        deletion                = true
+        non_fast_forward        = true
+        required_linear_history = true
+        pull_request = {
+          required_approving_review_count   = 0
+          dismiss_stale_reviews_on_push     = true
+          require_code_owner_review         = false
+          required_review_thread_resolution = true
+        }
+      }
+      bypass_actors = [
+        {
+          actor_id    = tonumber(var.gha_app_id)
+          actor_type  = "Integration"
+          bypass_mode = "always"
+        },
+      ]
+    }
+  }
 }

--- a/terraform/src/repositories/homebrew-tap/variables.tf
+++ b/terraform/src/repositories/homebrew-tap/variables.tf
@@ -3,3 +3,8 @@ variable "github_token" {
   description = "GitHub token"
   sensitive   = true
 }
+
+variable "gha_app_id" {
+  type        = string
+  description = "goreleaser が Formula/*.rb を push するための GitHub App の numeric App ID (ruleset bypass actor 用)"
+}


### PR DESCRIPTION

## 📒 変更の概要

- `project-words.txt` に `goreleaser` を追加しました。
- GitHub Actions の `terraform-apply` と `terraform-plan` に `GHA_APP_ID` の入力を追加しました。
- `terraform-github.yml` で `GHA_APP_ID` を使用するように変更しました。
- `main.tf` において、`goreleaser` が Formula/*.rb を直接 push できるようにカスタムの main 保護を定義しました。
- `variables.tf` に `gha_app_id` 変数を追加しました。

## ⚒ 技術的詳細

- `terraform/src/repositories/homebrew-tap/main.tf` で、`goreleaser` を bypass actor として登録するためのカスタム main 保護を設定しました。この設定により、`goreleaser` が直接リポジトリに変更を加えることができるようになります。
- `branch_rulesets` で、`main` ブランチに対するルールを定義し、`bypass_actors` に `goreleaser` の App ID を指定しました。

```mermaid
graph TD;
    A[goreleaser] -->|push| B[main branch];
    B --> C{branch rulesets};
    C -->|bypass| D[custom protection];
```

## ⚠ 注意点

- `GHA_APP_ID` はオプションですが、`goreleaser` を使用する場合は正しい App ID を設定する必要があります。設定しないと、`goreleaser` がリポジトリに変更を加えることができません。