### PR TITLE
✨ agent-foundry リポジトリを Terraform 管理に追加

### DIFF
--- a/terraform/src/repositories/agent-foundry/main.tf
+++ b/terraform/src/repositories/agent-foundry/main.tf
@@ -1,0 +1,18 @@
+module "this" {
+  source       = "../../../modules/repository"
+  github_token = var.github_token
+
+  repository          = "agent-foundry"
+  owner               = "tqer39"
+  default_branch      = "main"
+  enable_owner_bypass = true
+  visibility          = "private"
+  description         = "LLM agent orchestration foundry: Founder Agent, Agent Factory, and agent organization design."
+  topics = [
+    "ai-agents",
+    "multi-agent",
+    "llm",
+    "agent-orchestration",
+    "founder-agent",
+  ]
+}

--- a/terraform/src/repositories/agent-foundry/outputs.tf
+++ b/terraform/src/repositories/agent-foundry/outputs.tf
@@ -1,0 +1,1 @@
+# Outputs can be added here if needed

--- a/terraform/src/repositories/agent-foundry/providers.tf
+++ b/terraform/src/repositories/agent-foundry/providers.tf
@@ -1,0 +1,4 @@
+provider "github" {
+  owner = "tqer39"
+  token = var.github_token
+}

--- a/terraform/src/repositories/agent-foundry/terraform.tf
+++ b/terraform/src/repositories/agent-foundry/terraform.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = "1.14.9"
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "6.11.1"
+    }
+  }
+  backend "s3" {
+    bucket  = "terraform-tfstate-tqer39-072693953877-ap-northeast-1"
+    key     = "terraform-github/repositories/agent-foundry.tfstate"
+    region  = "ap-northeast-1"
+    encrypt = true
+  }
+}

--- a/terraform/src/repositories/agent-foundry/variables.tf
+++ b/terraform/src/repositories/agent-foundry/variables.tf
@@ -1,0 +1,5 @@
+variable "github_token" {
+  type        = string
+  description = "GitHub token"
+  sensitive   = true
+}


### PR DESCRIPTION

## 📒 変更の概要

- 新しいファイル `main.tf`, `outputs.tf`, `providers.tf`, `terraform.tf`, `variables.tf` を `terraform/src/repositories/agent-foundry/` に追加しました。
- これにより、`agent-foundry` リポジトリが Terraform によって管理されるようになります。

## ⚒ 技術的詳細

- `main.tf` では、GitHub リポジトリの設定が行われています。リポジトリ名は `agent-foundry` で、オーナーは `tqer39` です。
- `providers.tf` では、GitHub プロバイダーの設定が含まれており、GitHub トークンが必要です。
- `terraform.tf` では、Terraform のバージョンとプロバイダーの設定が指定されています。また、S3 バックエンドが設定されており、状態ファイルが指定されたバケットに保存されます。
- `variables.tf` では、GitHub トークンの変数が定義されています。このトークンはセンシティブな情報として扱われます。

## ⚠ 注意点

> [!WARNING]
>
> - 💣 GitHub トークンはセンシティブな情報です。適切に管理してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established infrastructure configuration for a new private repository with default settings, access controls, and topic classification for repository organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->