### PR TITLE
自動マージ機能の改善とclaude-autoラベルの廃止

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,12 +1,13 @@
 ---
 name: create-pr
-description: 現在のブランチから PR を作成する（自動 push + claude-auto ラベル付与）
+description: 現在のブランチから PR を作成する（自動 push）
 allowed-tools: [Bash]
 ---
 
 # Create PR
 
-現在のブランチから main に対して PR を作成する。未 push なら自動で push し、`claude-auto` ラベルを付与する。
+現在のブランチから main に対して PR を作成する。未 push なら自動で push する。
+ブランチ名が `renovate/*` `worktree-*` `ccw-*` のいずれかであれば、`auto-merge.yml` が自動 approve + auto-merge を発火する（ラベル不要）。
 
 ## 手順
 
@@ -32,7 +33,7 @@ allowed-tools: [Bash]
 - 以下のコマンドで PR を作成する:
 
 ```bash
-gh pr create --base main --fill --label claude-auto
+gh pr create --base main --fill
 ```
 
 ### 5. 結果の表示

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,12 +2,10 @@ name: Auto Merge
 
 on:
   pull_request:
-    types: [labeled]
-  check_suite:
-    types: [completed]
+    types: [opened, reopened, ready_for_review, synchronize]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.check_suite.id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -15,8 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: >-
-      (github.event_name == 'pull_request' && github.event.label.name == 'claude-auto') ||
-      github.event_name == 'check_suite'
+      startsWith(github.event.pull_request.head.ref, 'renovate/') ||
+      startsWith(github.event.pull_request.head.ref, 'worktree-') ||
+      startsWith(github.event.pull_request.head.ref, 'ccw-')
     permissions:
       contents: read
       pull-requests: read
@@ -28,46 +27,20 @@ jobs:
           app-id: ${{ secrets.GHA_APP_ID }}
           private-key: ${{ secrets.GHA_APP_PRIVATE_KEY }}
 
-      - name: PR 番号の取得
-        id: pr
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          else
-            PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.check_suite.head_sha }}/pulls" \
-              --jq '.[0].number // empty')
-            echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: claude-auto ラベルの確認
-        if: steps.pr.outputs.number != ''
-        id: label-check
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          HAS_LABEL=$(gh pr view "${{ steps.pr.outputs.number }}" \
-            --repo "${{ github.repository }}" \
-            --json labels --jq '[.labels[].name] | any(. == "claude-auto")')
-          echo "has_label=${HAS_LABEL}" >> "$GITHUB_OUTPUT"
-
       - name: PR の approve
-        if: steps.pr.outputs.number != '' && steps.label-check.outputs.has_label == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh pr review "${{ steps.pr.outputs.number }}" \
+          gh pr review "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
             --approve \
-            --body "GitHub App による自動承認（claude-auto ラベル検出）"
+            --body "GitHub App による自動承認（自動マージ対象ブランチ）"
 
       - name: auto-merge の有効化（squash）
-        if: steps.pr.outputs.number != '' && steps.label-check.outputs.has_label == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh pr merge "${{ steps.pr.outputs.number }}" \
+          gh pr merge "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
             --squash \
             --auto


### PR DESCRIPTION

## 📒 変更の概要

- `create-pr.md`ファイルの説明を更新し、`claude-auto`ラベルの付与を廃止しました。
- `auto-merge.yml`ワークフローのトリガーを変更し、`claude-auto`ラベルに依存しない自動マージを実現しました。

## ⚒ 技術的詳細

- `create-pr.md`:
  - PR作成時に自動で`claude-auto`ラベルを付与する機能を削除しました。
  - 特定のブランチ名（`renovate/*`, `worktree-*`, `ccw-*`）に対して自動承認と自動マージを行うように変更しました。

- `auto-merge.yml`:
  - PRがオープン、再オープン、レビュー準備完了、または同期されたときに自動マージがトリガーされるように設定しました。
  - `claude-auto`ラベルの確認を削除し、ブランチ名に基づいて自動承認とマージを行うようにしました。

## ⚠ 注意点

- 💡 新しいワークフローでは、特定のブランチ名に基づいて自動マージが行われるため、ブランチ名の命名規則に注意してください。
- ⚠ 既存のPRに対しては、`claude-auto`ラベルが必要なくなるため、ラベルの管理が不要になりますが、ブランチ名の確認が重要です。