### PR TITLE
🛠️ auto-commit.md の mise tasks への更新

### DIFF
--- a/.claude/commands/auto-commit.md
+++ b/.claude/commands/auto-commit.md
@@ -33,11 +33,11 @@ allowed-tools: [Bash, Read, Glob, Grep]
 
 ### 4. Lint チェック
 
-- `just lint` を実行する
+- `mise run dev:lint` を実行する
 - 失敗した場合:
-  - エラー内容を確認し、`just fix` または手動で修正する
+  - エラー内容を確認し、`mise run dev:fix` または手動で修正する
   - 修正したファイルを再ステージング（ステップ 3 のルールに従う）
-  - `just lint` を再実行してパスを確認する
+  - `mise run dev:lint` を再実行してパスを確認する
 - **パスするまでコミットに進まない**
 
 ### 5. コミットメッセージの生成


### PR DESCRIPTION

## 📒 Summary of Changes

- 🔄 `just lint` を `mise run dev:lint` に変更。
- 🔄 `just fix` を `mise run dev:fix` に変更。

## ⚒ Technical Details

- 📄 `auto-commit.md` ファイルの内容を更新し、Lint チェックとコミットメッセージ生成の手順を `mise` コマンドに合わせて修正。

## ⚠ Points of Caution

- ⚠️ 新しいコマンドに依存するため、`mise` が正しくインストールされていることを確認してください。