### PR TITLE
✨ .terraform.lock.hcl 欠落を検出する lefthook フックを追加

### DIFF
--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -47,6 +47,7 @@ terraform import module.this.github_repository_ruleset.this[\"<ruleset_name>\"] 
 | `mise run dev:lint-hook -- <hook>` | 特定フックを実行（terraform_fmt, terraform_validate, terraform_tflint, yamllint, markdownlint） |
 | `mise run dev:fix` | よくある問題を自動修正 |
 | `mise run dev:fmt-staged` | ステージ済みファイルをフォーマット |
+| `scripts/lint/check-terraform-lock.sh` | `terraform/src/repositories/<repo>/` 配下の `.terraform.lock.hcl` 欠落を検出（lefthook の `check-terraform-lock` フックから自動実行） |
 
 ## Git Worktree
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -35,6 +35,9 @@ pre-commit:
     shellcheck:
       glob: "*.sh"
       run: shellcheck {staged_files}
+    check-terraform-lock:
+      glob: "terraform/src/repositories/**"
+      run: scripts/lint/check-terraform-lock.sh
     markdownlint:
       glob: "*.{md,markdown}"
       run: pnpm exec markdownlint-cli2 --fix {staged_files}

--- a/scripts/lint/check-terraform-lock.sh
+++ b/scripts/lint/check-terraform-lock.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Fail if any terraform/src/repositories/<repo>/ directory is missing .terraform.lock.hcl.
+# Prevents new-repository PRs from being merged without the provider lock file.
+set -euo pipefail
+
+repo_root="terraform/src/repositories"
+
+if [[ ! -d "$repo_root" ]]; then
+  exit 0
+fi
+
+missing=()
+while IFS= read -r -d '' dir; do
+  if [[ ! -f "$dir/.terraform.lock.hcl" ]]; then
+    missing+=("$dir")
+  fi
+done < <(find "$repo_root" -mindepth 1 -maxdepth 1 -type d -print0)
+
+if (( ${#missing[@]} > 0 )); then
+  {
+    echo "Missing .terraform.lock.hcl in the following repository directories:"
+    for d in "${missing[@]}"; do
+      echo "  - $d"
+    done
+    echo
+    echo "Run 'terraform -chdir=<dir> init' to generate the lock file, then commit it."
+  } >&2
+  exit 1
+fi


### PR DESCRIPTION

## 📒 Summary of Changes

- 🛠️ `lefthook` に `.terraform.lock.hcl` 欠落を検出するフックを追加。
- 📜 `scripts/lint/check-terraform-lock.sh` スクリプトを新規作成。

## ⚒ Technical Details

- 📁 `lefthook.yml` に `check-terraform-lock` フックを追加し、特定のディレクトリ内でスクリプトを実行。
- 📝 `scripts/lint/check-terraform-lock.sh` では、指定されたディレクトリ内の `.terraform.lock.hcl` ファイルの存在を確認。

## ⚠ Points of Caution

- ⚠️ 新しいリポジトリの PR がプロバイダーロックファイルなしでマージされないようにするための重要なチェックです。