### PR TITLE
🌱 新しいKubernetesリポジトリの追加

### DIFF
--- a/terraform/src/repositories/learn-kubernetes/.terraform.lock.hcl
+++ b/terraform/src/repositories/learn-kubernetes/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.12.1"
+  constraints = "6.12.1"
+  hashes = [
+    "h1:/JLvYf7fCYeSoKc89py9WV94WnTgT71A3U4VaTPegpI=",
+    "h1:8bdqUshpu+zpfdHQVZ1Rg1rSaW9nSv1gzHt4HRPaZUk=",
+    "h1:9BfXk4BJJWZkaa/d/8i+U3u7Nr3tlGIHJ+7LBvc12gw=",
+    "h1:AkdRKjzShTel609CiVGyv3vWU7Qo8mwcUE6VJV/Gres=",
+    "h1:CmFsDWVQMUHitg2Lyqv/qI+lLXPv7J157Rv8YvQoPLY=",
+    "h1:Ekz3/V2jj7Tvw4WgDLmjTK+BWg9Eq/AIo1QcihXZqOU=",
+    "h1:HXXTIvXPBVJ4mBs01fcJk7wG8N3jGvR/4HqjnRGp4Wo=",
+    "h1:IVEhTwWpf1T+NXuY6J+KVY4mSjqyp5OdC5RI7MZQnNc=",
+    "h1:bGz4LIep/7PVrqy6P8cTYbAJpdxXGrupUJjkCczlzIs=",
+    "h1:ghFGRYa6LdR4BjW0Fe8HXKI0ZmA1bTrwjhXDeZG7+3E=",
+    "h1:hHOwf554tYL9pQS2uRPbaAGSXRbbBJ/+HtQAoT9mtuA=",
+    "h1:udibqwcJrxhB4bIvNfRcFNClzgRCMWRmQ9CGwXrOVL4=",
+    "h1:w0nsMBpbxXyt2qzN7+3cHjGmJC73ROGBSJTcexcHuyA=",
+    "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
+    "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
+    "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",
+    "zh:5a70b5d2ac650c5c9819a1875411ebda229d0fcc6c9f57f9d751852ca3cd77ac",
+    "zh:8668d93bd4dc2ffa2545e1473af600a925d479b16033a71a4498a16f3b683c0c",
+    "zh:86eacc6059fd057948e178b665ba5cce74bd5488a9e1035734e60ff5ef1b6f8f",
+    "zh:a329fac98881d8dfc211a9bdc0ec6f2948f0b0c2704d1b6cbe5307403c7ad1b2",
+    "zh:dadd44abab3c52b9d572955afaef1658790e17ea355ee22b58996d81d28e02d8",
+    "zh:de9f455ef342cc38fb76bce844bfcd376fb81a4b9f9bc2fae023ff99efdf1338",
+    "zh:f8c6d2e8351b334491790358574e0a30a7c6d7f5b80f7daf32a7c0f3e9b1ab19",
+    "zh:fab41971a3edee04ab6eceaeab4eeb9a2b2f38a2af3b06eda93e2117b64994be",
+    "zh:fb1279b566dd9c8c117b2e4e0cc8344413b8fc8f2a3e24be22a9b2610551777b",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fe79d2a861fb9af420fa5bd7f02c031b2a0a3edf5dbc46022c8ecc7a33cf2b6d",
+  ]
+}

--- a/terraform/src/repositories/learn-kubernetes/main.tf
+++ b/terraform/src/repositories/learn-kubernetes/main.tf
@@ -1,0 +1,17 @@
+module "this" {
+  source       = "../../../modules/repository"
+  github_token = var.github_token
+
+  repository          = "learn-kubernetes"
+  owner               = "tqer39"
+  default_branch      = "main"
+  enable_owner_bypass = true
+  visibility          = "public"
+  description         = "Kubernetes learning playground: manifests, kubectl exercises, and cluster experiments."
+  topics = [
+    "kubernetes",
+    "k8s",
+    "learning",
+    "playground",
+  ]
+}

--- a/terraform/src/repositories/learn-kubernetes/outputs.tf
+++ b/terraform/src/repositories/learn-kubernetes/outputs.tf
@@ -1,0 +1,1 @@
+# Outputs can be added here if needed

--- a/terraform/src/repositories/learn-kubernetes/providers.tf
+++ b/terraform/src/repositories/learn-kubernetes/providers.tf
@@ -1,0 +1,4 @@
+provider "github" {
+  owner = "tqer39"
+  token = var.github_token
+}

--- a/terraform/src/repositories/learn-kubernetes/terraform.tf
+++ b/terraform/src/repositories/learn-kubernetes/terraform.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = "1.15.4"
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "6.12.1"
+    }
+  }
+  backend "s3" {
+    bucket  = "terraform-tfstate-tqer39-072693953877-ap-northeast-1"
+    key     = "terraform-github/repositories/learn-kubernetes.tfstate"
+    region  = "ap-northeast-1"
+    encrypt = true
+  }
+}

--- a/terraform/src/repositories/learn-kubernetes/variables.tf
+++ b/terraform/src/repositories/learn-kubernetes/variables.tf
@@ -1,0 +1,5 @@
+variable "github_token" {
+  type        = string
+  description = "GitHub token"
+  sensitive   = true
+}


### PR DESCRIPTION

## 📒 Summary of Changes

- 🆕 `learn-kubernetes`リポジトリを追加しました。
- 🔧 Terraform設定ファイルを作成しました。

## ⚒ Technical Details

- 📁 新しいファイル `terraform/src/repositories/learn-kubernetes/.terraform.lock.hcl` を追加しました。
- 📁 新しいファイル `terraform/src/repositories/learn-kubernetes/main.tf` を追加しました。
- 📁 新しいファイル `terraform/src/repositories/learn-kubernetes/outputs.tf` を追加しました。
- 📁 新しいファイル `terraform/src/repositories/learn-kubernetes/providers.tf` を追加しました。
- 📁 新しいファイル `terraform/src/repositories/learn-kubernetes/terraform.tf` を追加しました。
- 📁 新しいファイル `terraform/src/repositories/learn-kubernetes/variables.tf` を追加しました。

## ⚠ Points of Caution

- 🔒 `github_token`変数はセンシティブな情報であるため、適切に管理してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added infrastructure-as-code configuration for automated repository management via Terraform, including provider setup, remote state storage, and variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->